### PR TITLE
QL: install: fix Yosys techmaps handling

### DIFF
--- a/quicklogic/CMakeLists.txt
+++ b/quicklogic/CMakeLists.txt
@@ -8,6 +8,11 @@ add_custom_target(QL_CELLS_SIM_DEPS)
 include(cmake/cells_sim_gen.cmake)
 add_subdirectory(primitives)
 
+set(CELLS_MAP_FILE ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/techmap/cells_map.v)
+set(CELLS_MAP_FILE_DEST_DIR ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/techmap/)
+# copy map file to binary dir
+file(COPY ${CELLS_MAP_FILE} DESTINATION ${CELLS_MAP_FILE_DEST_DIR})
+
 set(CELLS_SIM_FILE ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/techmap/cells_sim.v)
 add_cells_sim_target(${CELLS_SIM_FILE})
 
@@ -49,6 +54,7 @@ define_arch(
   ARCH ql-s3
   YOSYS_SYNTH_SCRIPT ${YOSYS_SYNTH_SCRIPT}
   YOSYS_CONV_SCRIPT ${YOSYS_CONV_SCRIPT}
+  YOSYS_TECHMAP ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/techmap
   DEVICE_FULL_TEMPLATE \${DEVICE}
   VPR_ARCH_ARGS ${VPR_ARCH_ARGS}
 

--- a/quicklogic/cmake/cells_sim_gen.cmake
+++ b/quicklogic/cmake/cells_sim_gen.cmake
@@ -1,4 +1,4 @@
-function(ADD_CELLS_SIM_TARGET output_file)
+FUNCTION(ADD_CELLS_SIM_TARGET OUTPUT_FILE)
   # ~~~
   # ADD_CELLS_SIM_TARGET(<output_file>)
 
@@ -12,14 +12,14 @@ function(ADD_CELLS_SIM_TARGET output_file)
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/techmap)
 
   add_custom_command(
-    OUTPUT ${output_file}
+    OUTPUT ${OUTPUT_FILE}
     DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ${CONCATENATE_V_SOURCES_PY} QL_CELLS_SIM_DEPS
             ql_cells_sim_tech_dir
-    COMMAND ${PYTHON3} ${CONCATENATE_V_SOURCES_PY} ${VERILOG_SOURCES} ${output_file}
+    COMMAND ${PYTHON3} ${CONCATENATE_V_SOURCES_PY} ${VERILOG_SOURCES} ${OUTPUT_FILE}
     COMMAND_EXPAND_LISTS
-    COMMENT "Generating ${output_file}"
+    COMMENT "Generating ${OUTPUT_FILE}"
     )
-  add_file_target(FILE ${output_file} GENERATED ABSOLUTE)
+  add_file_target(FILE ${OUTPUT_FILE} GENERATED ABSOLUTE)
 endfunction(ADD_CELLS_SIM_TARGET)
 
 function(ADD_TO_CELLS_SIM file)


### PR DESCRIPTION
This PR fixes the problem introduced in #4 causing the regular flow to fail on missing yosys techmaps