### PR TITLE
VPR with analysis fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr 8.0.0.rc2_3935_g7d6424bb0 20200514_163723"
+  PACKAGE_SPEC "vtr 8.0.0.rc2_4003_g8980e4621 20200527_075234"
   )
 add_conda_package(
   NAME libxslt


### PR DESCRIPTION
This PR changes the version of VPR conda package to one with fixed bug related to `<design>_analysis` targets. Once this PR is merge there is no need for supplying external VPR to SymbiFlow.

Signed-off-by: Maciej Kurc <mkurc@antmicro.com>