### PR TITLE
Fixes for GMUX and CLOCK

### DIFF
--- a/quicklogic/CMakeLists.txt
+++ b/quicklogic/CMakeLists.txt
@@ -83,6 +83,17 @@ define_arch(
         --pcf \${INPUT_IO_FILE} \
         --net \${OUT_NET}"
 
+  PLACE_CONSTR_TOOL
+    ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/utils/create_place_constraints.py
+  PLACE_CONSTR_TOOL_CMD "${CMAKE_COMMAND} -E env \
+    PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils \
+    \${PYTHON3} \${PLACE_CONSTR_TOOL} \
+        --map ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/\${BOARD}_clkmap.csv \
+        --blif \${OUT_EBLIF} \
+        --i /dev/stdin \
+        --o /dev/stdout \
+        \${PLACE_CONSTR_TOOL_EXTRA_ARGS}"
+
   FASM_TO_BIT
     ${QLFASM}
   FASM_TO_BIT_CMD "\${PYTHON3} \
@@ -112,7 +123,6 @@ define_arch(
     ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/utils/verilogmodule.py
     ${CMAKE_CURRENT_BINARY_DIR}/devices/\${DEVICE_TYPE}/db_vpr.pickle
   NO_BIT_TIME
-  NO_PLACE_CONSTR
   ROUTE_CHAN_WIDTH 100
   USE_FASM
 )

--- a/quicklogic/cmake/install.cmake
+++ b/quicklogic/cmake/install.cmake
@@ -72,6 +72,10 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
           DESTINATION bin/python
           PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
 
+  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/utils/create_place_constraints.py
+          DESTINATION bin/python
+          PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
+
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/utils/fasm2bels.py
           DESTINATION bin/python
           PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
@@ -221,4 +225,17 @@ function(DEFINE_QL_PINMAP_CSV_INSTALL_TARGET)
   install(FILES ${PINMAP_FILE}
     DESTINATION "share/arch/${DEVICE}_${PACKAGE}/${PART}"
     RENAME "pinmap_${ADD_QUICKLOGIC_BOARD_FABRIC_PACKAGE}.csv")
+
+  get_target_property_required(CLKMAP ${BOARD} CLKMAP)
+  get_file_location(CLKMAP_FILE ${CLKMAP})
+  get_filename_component(CLKMAP_FILE_NAME ${CLKMAP_FILE} NAME)
+  append_file_dependency(DEPS ${CLKMAP})
+  add_custom_target(
+    "CLKMAP_INSTALL_${BOARD}_${DEVICE}_${PACKAGE}_${CLKMAP_FILE_NAME}"
+    ALL
+    DEPENDS ${DEPS}
+    )
+  install(FILES ${CLKMAP_FILE}
+    DESTINATION "share/arch/${DEVICE}_${PACKAGE}/${PART}"
+    RENAME "clkmap_${ADD_QUICKLOGIC_BOARD_FABRIC_PACKAGE}.csv")
 endfunction()

--- a/quicklogic/primitives/gmux/CMakeLists.txt
+++ b/quicklogic/primitives/gmux/CMakeLists.txt
@@ -8,3 +8,6 @@ v2x(NAME gmux SRCS gmux.sim.v)
 
 add_to_cells_sim(gmux_ip.sim.v)
 add_to_cells_sim(gmux_ic.sim.v)
+
+add_file_target(FILE gmux_proxy.v SCANNER_TYPE verilog)
+add_to_cells_sim(gmux_proxy.v)

--- a/quicklogic/primitives/gmux/gmux_proxy.v
+++ b/quicklogic/primitives/gmux/gmux_proxy.v
@@ -1,0 +1,12 @@
+// This is a "proxy" cell for a GMUX connected to CLOCK. It is inserted by
+// Yosys and techmapped to a GMUX_IP with IS0=1'b1
+
+(* whitebox *)
+module GMUX_PROXY (IP, IZ);
+    input  wire IP;
+    (* clkbuf_driver *)
+    output wire IZ;
+
+    assign IZ = IP;
+
+endmodule

--- a/quicklogic/techmap/cells_map.v
+++ b/quicklogic/techmap/cells_map.v
@@ -367,6 +367,87 @@ module inv (
 endmodule
 
 // ============================================================================
+// Multiplexers
+
+module mux4x0 (
+    output Q,
+    input  S0,
+    input  S1,
+    input  A,
+    input  B,
+    input  C,
+    input  D
+);
+
+  // T_FRAG to be packed either into T_FRAG or B_FRAG.
+  T_FRAG # (
+  .XAS1(1'b0),
+  .XAS2(1'b0),
+  .XBS1(1'b0),
+  .XBS2(1'b0)
+  )
+  t_frag (
+  .TBS(1'b1), // Always route to const1
+  .XAB(S1),
+  .XSL(S0),
+  .XA1(A),
+  .XA2(B),
+  .XB1(C),
+  .XB2(D),
+  .XZ (O)
+  );
+
+endmodule
+
+module mux8x0 (
+    output Q,
+    input  S0,
+    input  S1,
+    input  S2,
+    input  A,
+    input  B,
+    input  C,
+    input  D,
+    input  E,
+    input  F,
+    input  G,
+    input  H
+);
+
+  // Split into 2x mux4x0 plus a F_FRAG
+
+  wire q0, q1;
+
+  mux4x0 mux_0 (
+  .A (A),
+  .B (B),
+  .C (C),
+  .D (D),
+  .S0(S0),
+  .S1(S1),
+  .Q (q0)
+  );
+
+  mux4x0 mux_1 (
+  .A (E),
+  .B (F),
+  .C (G),
+  .D (H),
+  .S0(S0),
+  .S1(S1),
+  .Q (q1)
+  );
+
+  F_FRAG f_frag (
+  .F1(q0),
+  .F2(q1),
+  .FS(S2),
+  .FZ(Q)
+  );
+
+endmodule
+
+// ============================================================================
 // LUTs
 
 module LUT1 (
@@ -528,64 +609,6 @@ module LUT4 (
     .FS(I3),
     .FZ(O)
   );
-
-endmodule
-
-module mux8x0 (
-  output Q,
-  input S0,
-  input S1,
-  input S2,
-  input A,
-  input B,
-  input C,
-  input D,
-  input E,
-  input F,
-  input G,
-  input H
-);
-
-  C_FRAG c_frag (
-    .TBS(S2),
-    .TAB(S1),
-    .TSL(S0),
-    .TA1(A),
-    .TA2(B),
-    .TB1(C),
-    .TB2(D),
-    .BAB(S1),
-    .BSL(S0),
-    .BA1(E),
-    .BA2(F),
-    .BB1(G),
-    .BB2(H),
-    .TZ(),
-    .CZ(Q)
-);
-
-endmodule
-
-module mux4x0 (
-  output Q,
-  input S0,
-  input S1,
-  input A,
-  input B,
-  input C,
-  input D
-);
- // T_FRAG can be mapped to T or B frag
- T_FRAG t_frag (
-  .TBS(1'b1),
-  .XAB(S1),
-  .XSL(S0),
-  .XA1(A),
-  .XA2(B),
-  .XB1(C),
-  .XB2(D),
-  .XZ(Q)
-);
 
 endmodule
 

--- a/quicklogic/techmap/cells_map.v
+++ b/quicklogic/techmap/cells_map.v
@@ -209,6 +209,18 @@ module gclkbuff(input A, output Z);
 
 endmodule
 
+module GMUX_PROXY(input IP, output IZ);
+
+  // Map to the GMUX variant for the CLOCK -> GMUX connection. Connect the
+  // select input to VCC.
+  GMUX_IP _TECHMAP_REPLACE_ (
+  .IP  (IP),
+  .IZ  (IZ),
+  .IS0 (1'b1)
+  );
+
+endmodule
+
 // ============================================================================
 
 module C_FRAG (TBS, TAB, TSL, TA1, TA2, TB1, TB2, BAB, BSL, BA1, BA2, BB1, BB2, TZ, CZ);

--- a/quicklogic/tests/CMakeLists.txt
+++ b/quicklogic/tests/CMakeLists.txt
@@ -18,6 +18,9 @@ add_subdirectory(sdiomux_xor)
 add_subdirectory(ext_counter)
 add_subdirectory(ext_mult)
 
+# Global clock network tests
+add_subdirectory(gclk_counter)
+
 # Test designs that use clock
 add_subdirectory(counter)
 add_subdirectory(soc_clocks)

--- a/quicklogic/tests/gclk_counter/CMakeLists.txt
+++ b/quicklogic/tests/gclk_counter/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_file_target(FILE gclk_counter.v SCANNER_TYPE verilog)
+add_file_target(FILE chandalar.pcf)
+
+add_fpga_target(
+  NAME gclk_counter-ql-chandalar
+  BOARD chandalar
+  SOURCES gclk_counter.v
+  INPUT_IO_FILE chandalar.pcf
+  EXPLICIT_ADD_FILE_TARGET
+  )
+
+add_jlink_output(
+  PARENT gclk_counter-ql-chandalar
+)
+
+add_dependencies(all_ql_tests gclk_counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests gclk_counter-ql-chandalar_jlink)

--- a/quicklogic/tests/gclk_counter/README.md
+++ b/quicklogic/tests/gclk_counter/README.md
@@ -1,0 +1,5 @@
+# A test for extrernal global clock inputs (CLOCK pad via GMUX)
+
+This tests consists of two counters clocked by external clock signals which enter the fabric using dedicated clock inputs.
+
+For the Chandalar board LEDs 0 and 1 correspond to bits 23 and 24 of a counter clocked by the CLK0 input while LEDs 2 and 3 correspond to bits 23 and 24 of a counter clocked by the CLK1 input. The CLK0 is available on J6.4 pin and CLK1 on J6.6 pin.

--- a/quicklogic/tests/gclk_counter/chandalar.pcf
+++ b/quicklogic/tests/gclk_counter/chandalar.pcf
@@ -1,0 +1,7 @@
+set_io clk(0)   G6 # GPIO24 CLK0 IO81 G6 S3B_AP_I2S_DOUT     J6.4
+set_io clk(1)   H6 # GPIO23 CLK1 IO77 H6 S3B_AP_I2S_WD_CLKIN J6.6
+
+set_io led(0)   H7
+set_io led(1)   G7
+set_io led(2)   F6
+set_io led(3)   E8

--- a/quicklogic/tests/gclk_counter/gclk_counter.v
+++ b/quicklogic/tests/gclk_counter/gclk_counter.v
@@ -3,50 +3,22 @@ module top(
     output wire [3:0] led
 );
 
-    // Clock pads
-    wire [1:0] pclk;
-
-    ckpad pad0 (
-        .P(clk[0]),
-        .Q(pclk[0]),
-    );
-    ckpad pad1 (
-        .P(clk[1]),
-        .Q(pclk[1]),
-    );
-
-    // Manual GMUXes for IPs
-    wire [1:0] gclk;
-
-    GMUX_IP gmux0 (
-        .IP  (pclk[0]),
-        .IC  (1'b0),
-        .IS0 (1'b0), // Select the CLOCK pad
-        .IZ  (gclk[0])
-    );
-    GMUX_IP gmux1 (
-        .IP  (pclk[1]),
-        .IC  (1'b0),
-        .IS0 (1'b0), // Select the CLOCK pad
-        .IZ  (gclk[1])
-    );
-
     // Counters
     reg [23:0] cnt0;
     initial cnt0 <= 0;
-    always @(posedge gclk[0])
+    always @(posedge clk[0])
         cnt0 <= cnt0 + 1;
 
     reg [23:0] cnt1;
     initial cnt1 <= 0;
-    always @(posedge gclk[1])
+    always @(posedge clk[1])
         cnt1 <= cnt1 + 1;
 
     // Outputs
-    assign led[0] = cnt0[23];
-    assign led[1] = cnt0[24];
+    assign led[0] = cnt0[22];
+    assign led[1] = cnt0[23];
 
-    assign led[2] = cnt1[23];
-    assign led[3] = cnt1[24];
+    assign led[2] = cnt1[22];
+    assign led[3] = cnt1[23];
 
 endmodule

--- a/quicklogic/tests/gclk_counter/gclk_counter.v
+++ b/quicklogic/tests/gclk_counter/gclk_counter.v
@@ -1,0 +1,52 @@
+module top(
+    input  wire [1:0] clk,
+    output wire [3:0] led
+);
+
+    // Clock pads
+    wire [1:0] pclk;
+
+    ckpad pad0 (
+        .P(clk[0]),
+        .Q(pclk[0]),
+    );
+    ckpad pad1 (
+        .P(clk[1]),
+        .Q(pclk[1]),
+    );
+
+    // Manual GMUXes for IPs
+    wire [1:0] gclk;
+
+    GMUX_IP gmux0 (
+        .IP  (pclk[0]),
+        .IC  (1'b0),
+        .IS0 (1'b0), // Select the CLOCK pad
+        .IZ  (gclk[0])
+    );
+    GMUX_IP gmux1 (
+        .IP  (pclk[1]),
+        .IC  (1'b0),
+        .IS0 (1'b0), // Select the CLOCK pad
+        .IZ  (gclk[1])
+    );
+
+    // Counters
+    reg [23:0] cnt0;
+    initial cnt0 <= 0;
+    always @(posedge gclk[0])
+        cnt0 <= cnt0 + 1;
+
+    reg [23:0] cnt1;
+    initial cnt1 <= 0;
+    always @(posedge gclk[1])
+        cnt1 <= cnt1 + 1;
+
+    // Outputs
+    assign led[0] = cnt0[23];
+    assign led[1] = cnt0[24];
+
+    assign led[2] = cnt1[23];
+    assign led[3] = cnt1[24];
+
+endmodule

--- a/quicklogic/toolchain_wrappers/generate_constraints
+++ b/quicklogic/toolchain_wrappers/generate_constraints
@@ -13,19 +13,26 @@ ARCH_DEF=$6
 
 if ! [[ "$PART" =~ ^(PU64|WR42|PD64)$ ]]; then 
 	 PINMAPCSV="pinmap_PD64.csv"
+	 CLKMAPCSV="clkmap_PD64.csv"
 else
-         PINMAPCSV="pinmap_${PART}.csv"
+     PINMAPCSV="pinmap_${PART}.csv"
+     CLKMAPCSV="pinmap_${PART}.csv"
 fi
 
 echo "PINMAP FILE : $PINMAPCSV"
+echo "CLKMAP FILE : $CLKMAPCSV"
 
 CHANNELS=`realpath ${MYPATH}/../share/arch/${DEVICE}/channels.db`
 PINMAP=`realpath ${MYPATH}/../share/arch/${DEVICE}/${PINMAPCSV}`
+CLKMAP=`realpath ${MYPATH}/../share/arch/${DEVICE}/${CLKMAPCSV}`
 IOGEN=`realpath ${MYPATH}/python/create_ioplace.py`
+PLACEGEN=`realpath ${MYPATH}/python/create_place_constraints.py`
 CONSTR_GEN=`realpath ${MYPATH}/python/eos_s3_iomux_config.py`
 PROJECT=$(basename -- "$EBLIF")
 IOPLACE_FILE="${PROJECT%.*}_io.place"
+PLACE_FILE="${PROJECT%.*}_constraints.place"
 IOMUX_JLINK="${PROJECT%.*}_iomux.jlink"
 
 python3 ${IOGEN} --pcf $PCF --blif $EBLIF --map $PINMAP --net $NET > ${IOPLACE_FILE}
+python3 ${PLACEGEN} --blif $EBLIF --map $CLKMAP -i ${IOPLACE_FILE} > ${PLACE_FILE}
 python3 ${CONSTR_GEN} --eblif $EBLIF --pcf $PCF > ${IOMUX_JLINK}

--- a/quicklogic/toolchain_wrappers/place
+++ b/quicklogic/toolchain_wrappers/place
@@ -25,8 +25,20 @@ echo "Generating coinstrains ..."
 generate_constraints $PCF $EBLIF $NET $PART $DEVICE $ARCH_DEF
 
 PROJECT=$(basename -- "$EBLIF")
-IOPLACE_FILE="${PROJECT%.*}_io.place"
 
-run_vpr --fix_pins ${IOPLACE_FILE} --place
+#IOPLACE_FILE="${PROJECT%.*}_io.place"
+#PLACE_FILE="${PROJECT%.*}_io.place"
+#if [ -f
+
+IOPLACE_FILE="${PROJECT%.*}_io.place"
+PLACE_FILE="${PROJECT%.*}_constraints.place"
+
+if [ -f ${PLACE_FILE} ]; then
+    VPR_PLACE_FILE=${PLACE_FILE}
+else
+    VPR_PLACE_FILE=${IOPLACE_FILE}
+fi
+
+run_vpr --fix_pins ${VPR_PLACE_FILE} --place
 
 mv vpr_stdout.log place.log

--- a/quicklogic/utils/arch_import.py
+++ b/quicklogic/utils/arch_import.py
@@ -314,6 +314,9 @@ def main():
     for tile, sites in vpr_equivalent_sites.items():
         pb_names |= set(sites.keys())
 
+        # DEBUG
+        print(tile, list(sites.keys()))
+
     # Make list of arch tile types
     arch_tile_types = []
     for tile_type in vpr_tile_types.keys():

--- a/quicklogic/utils/arch_import.py
+++ b/quicklogic/utils/arch_import.py
@@ -399,9 +399,6 @@ def main():
         switches = db["switches"]
         connections = db["connections"]
 
-    # TODO: Do not support equivalent sites for tiles now
-    assert len(vpr_equivalent_sites) == 0, "Equivalent sites not supported yet!"
-
     # Flatten the VPR tilegrid
     flat_tile_grid = dict()
     for vpr_loc, tile in vpr_tile_grid.items():

--- a/quicklogic/utils/arch_import.py
+++ b/quicklogic/utils/arch_import.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python3
+import os
 import argparse
 import pickle
 from collections import namedtuple
+from collections import OrderedDict
 
 import lxml.etree as ET
 
 from data_structs import *
 
-from tile_import import make_top_level_model
 from tile_import import make_top_level_pb_type
 from tile_import import make_top_level_tile
-
-# =============================================================================
-
-ArchTileType = namedtuple("ArchTileType", "type is_tile is_pb_type")
 
 # =============================================================================
 
@@ -136,75 +133,75 @@ def initialize_arch(xml_arch, switches, segments):
         add_segment(xml_seglist, segment)
 
 
-def write_pb_types(xml_arch, pb_types, nsmap):
+def write_tiles(xml_arch, arch_tile_types, tile_types, equivalent_sites):
     """
-    Generates "models" and "complexblocklist" sections.
-    """
-
-    xi_include = "{{{}}}include".format(nsmap["xi"])
-
-
-def write_tiles(xml_arch, arch_tile_types, nsmap):
-    """
-    Generates "models", "complexblocklist" and "tiles" sections.
+    Generates the "tiles" section of the architecture file
     """
 
-    xi_include = "{{{}}}include".format(nsmap["xi"])
+    # The "tiles" section
+    xml_tiles = xml_arch.find("tiles")
+    if xml_tiles is None:
+        xml_tiles = ET.SubElement(xml_arch, "tiles")
 
-    # Tiles
-    xml_cplx = xml_arch.find("tiles")
-    if xml_cplx is None:
-        xml_cplx = ET.SubElement(xml_arch, "tiles")
+    # Add tiles
+    for tile_type, sub_tiles in arch_tile_types.items():
 
-    for tile_type in arch_tile_types:
-        if not tile_type.is_tile:
-            continue
-
-        tile_file = "{}.tile.xml".format(tile_type.type.lower())
-
-        ET.SubElement(
-            xml_cplx, xi_include, {
-                "href": "tl-{}".format(tile_file),
-            }
+        xml = make_top_level_tile(
+            tile_type, sub_tiles,
+            tile_types,
+            equivalent_sites
         )
 
-    # Models
-    xml_models = xml_arch.find("models")
-    if xml_models is None:
-        xml_models = ET.SubElement(xml_arch, "models")
+        xml_tiles.append(xml)
 
-    for tile_type in arch_tile_types:
-        if not tile_type.is_pb_type:
-            continue
 
-        model_file = "{}.model.xml".format(tile_type.type.lower())
-
-        ET.SubElement(
-            xml_models, xi_include, {
-                "href": "tl-{}".format(model_file),
-                "xpointer": "xpointer(models/child::node())",
-            }
-        )
+def write_pb_types(xml_arch, arch_pb_types, tile_types, nsmap):
+    """
+    Generates the "complexblocklist" section.
+    """
 
     # Complexblocklist
     xml_cplx = xml_arch.find("complexblocklist")
     if xml_cplx is None:
         xml_cplx = ET.SubElement(xml_arch, "complexblocklist")
 
-    for tile_type in arch_tile_types:
-        if not tile_type.is_pb_type:
-            continue
+    # Add pb_types
+    for pb_type in arch_pb_types:
 
-        pb_type_file = "{}.pb_type.xml".format(tile_type.type.lower())
+        xml = make_top_level_pb_type(tile_types[pb_type], nsmap)
+        xml_cplx.append(xml)
+
+
+def write_models(xml_arch, arch_models, nsmap):
+    """
+    Generates the "models" section.
+    """
+
+    # Models
+    xml_models = xml_arch.find("models")
+    if xml_models is None:
+        xml_models = ET.SubElement(xml_arch, "models")
+
+    # Include cell models
+    xi_include = "{{{}}}include".format(nsmap["xi"])
+    for model in arch_models:
+        name = model.lower()
+
+        # Be smart. Check if there is a file for that cell in the current
+        # directory. If not then use the one from "primitives" path
+        model_file = "./{}.model.xml".format(name)
+        if not os.path.isfile(model_file):
+            model_file = "../../primitives/{}/{}.model.xml".format(name, name)
 
         ET.SubElement(
-            xml_cplx, xi_include, {
-                "href": "tl-{}".format(pb_type_file),
+            xml_models, xi_include, {
+                "href": model_file,
+                "xpointer": "xpointer(models/child::node())",
             }
         )
 
 
-def write_tilegrid(xml_arch, tile_grid, loc_map, layout_name):
+def write_tilegrid(xml_arch, arch_tile_grid, loc_map, layout_name):
     """
     Generates the "layout" section of the arch XML and appends it to the
     root given.
@@ -216,8 +213,8 @@ def write_tilegrid(xml_arch, tile_grid, loc_map, layout_name):
         xml_arch.remove(xml_layout)
 
     # Grid size
-    xs = [loc.x for loc in tile_grid]
-    ys = [loc.y for loc in tile_grid]
+    xs = [flat_loc[0] for flat_loc in arch_tile_grid]
+    ys = [flat_loc[1] for flat_loc in arch_tile_grid]
     w = max(xs) + 1
     h = max(ys) + 1
 
@@ -232,32 +229,38 @@ def write_tilegrid(xml_arch, tile_grid, loc_map, layout_name):
     )
 
     # Individual tiles
-    for loc, tile in tile_grid.items():
+    for flat_loc, (tile_type, capacity) in arch_tile_grid.items():
 
-        if tile is None:
-            continue
-
+        # Single tile
         xml_sing = ET.SubElement(
             xml_fixed,
             "single",
             {
-                "type": "TL-{}".format(tile.type.upper()),
-                "x": str(loc.x),
-                "y": str(loc.y),
+                "type": "TL-{}".format(tile_type.upper()),
+                "x": str(flat_loc[0]),
+                "y": str(flat_loc[1]),
                 "priority": str(10),  # Not sure if we need this
             }
         )
 
-        if loc in loc_map.bwd:
-            phy_loc = loc_map.bwd[loc]
+        # Gather metadata
+        metadata = []
+        for i in range(capacity):
+            loc = Loc(x=flat_loc[0], y=flat_loc[1], z=i)
 
+            if loc in loc_map.bwd:
+                phy_loc = loc_map.bwd[loc]
+                metadata.append("X{}Y{}".format(phy_loc.x, phy_loc.y))
+
+        # Emit metadata if any
+        if len(metadata):
             xml_metadata = ET.SubElement(xml_sing, "metadata")
             xml_meta = ET.SubElement(
                 xml_metadata, "meta", {
                     "name": "fasm_prefix",
                 }
             )
-            xml_meta.text = "X{}Y{}".format(phy_loc.x, phy_loc.y)
+            xml_meta.text = " ".join(metadata)
 
 
 # =============================================================================
@@ -305,36 +308,68 @@ def main():
         segments = db["segments"]
         switches = db["switches"]
 
+    # TODO: Do not support equivalent sites for tiles now
+    assert len(vpr_equivalent_sites) == 0, "Equivalent sites not supported yet!"
+
+    # Flatten the VPR tilegrid
+    flat_tile_grid = dict()
+    for vpr_loc, tile in vpr_tile_grid.items():
+
+        if tile is None:
+            continue
+
+        flat_loc = (vpr_loc.x, vpr_loc.y)
+        if flat_loc not in flat_tile_grid:
+            flat_tile_grid[flat_loc] = {}
+
+        flat_tile_grid[flat_loc][vpr_loc.z] = tile.type
+
+    # Create the arch tile grid and arch tile types
+    arch_tile_grid  = dict()
+    arch_tile_types = dict()
+    arch_pb_types   = set()
+    arch_models     = set()
+
+    for flat_loc, tiles in flat_tile_grid.items():
+
+        # Group identical sub-tiles together, maintain their order
+        sub_tiles = OrderedDict()
+        for z, tile in tiles.items():
+            if tile not in sub_tiles:
+                sub_tiles[tile] = 0
+            sub_tiles[tile] += 1
+        
+        # TODO: Make arch tile type name
+        tile_type = tiles[0]
+
+        # Create the tile type with sub tile types for the arch
+        arch_tile_types[tile_type] = sub_tiles
+
+        # Add each sub-tile to top-level pb_type list
+        for tile in sub_tiles:
+            arch_pb_types.add(tile)
+
+        # Add each cell of a sub-tile to the model list
+        for tile in sub_tiles:
+            for cell_type in vpr_tile_types[tile].cells.keys():
+                arch_models.add(cell_type)
+
+        # Add the arch tile type to the arch tile grid
+        arch_tile_grid[flat_loc] = (tile_type, len(tiles),)
+
     # Initialize the arch XML if file not given
     xml_arch = ET.Element("architecture", nsmap=nsmap)
     initialize_arch(xml_arch, switches, segments)
 
-    # Make a list of pb_type names which are pb_type only, not tile.
-    pb_names = set()
-    for tile, sites in vpr_equivalent_sites.items():
-        pb_names |= set(sites.keys())
+    # Add tiles
+    write_tiles(xml_arch, arch_tile_types, vpr_tile_types, vpr_equivalent_sites)
+    # Add pb_types
+    write_pb_types(xml_arch, arch_pb_types, vpr_tile_types, nsmap)
+    # Add models
+    write_models(xml_arch, arch_models, nsmap)
 
-        # DEBUG
-        print(tile, list(sites.keys()))
-
-    # Make list of arch tile types
-    arch_tile_types = []
-    for tile_type in vpr_tile_types.keys():
-        arch_tile_types.append(
-            ArchTileType(
-                type = tile_type,
-                is_tile = \
-                    tile_type not in pb_names,
-                is_pb_type = \
-                    tile_type not in vpr_equivalent_sites or \
-                    tile_type in pb_names
-            )
-        )
-
-    # Write tiles
-    write_tiles(xml_arch, arch_tile_types, nsmap)
     # Write the tilegrid to arch
-    write_tilegrid(xml_arch, vpr_tile_grid, loc_map, args.device)
+    write_tilegrid(xml_arch, arch_tile_grid, loc_map, args.device)
 
     # Save the arch
     ET.ElementTree(xml_arch).write(
@@ -343,33 +378,6 @@ def main():
         xml_declaration=True,
         encoding="utf-8"
     )
-
-    # Generate tile, model and pb_type XMLs
-    for arch_tile in arch_tile_types:
-
-        # The top-level tile tag
-        if arch_tile.is_tile:
-
-            xml = make_top_level_tile(
-                arch_tile.type, vpr_tile_types,
-                vpr_equivalent_sites.get(arch_tile.type, None)
-            )
-
-            fname = "tl-{}.tile.xml".format(arch_tile.type.lower())
-            ET.ElementTree(xml).write(fname, pretty_print=True)
-
-        # The top-level pb_type and model
-        if arch_tile.is_pb_type:
-
-            tile_type = vpr_tile_types[arch_tile.type]
-
-            fname = "tl-{}.pb_type.xml".format(arch_tile.type.lower())
-            xml = make_top_level_pb_type(tile_type, nsmap)
-            ET.ElementTree(xml).write(fname, pretty_print=True)
-
-            fname = "tl-{}.model.xml".format(arch_tile.type.lower())
-            xml = make_top_level_model(tile_type, nsmap)
-            ET.ElementTree(xml).write(fname, pretty_print=True)
 
 
 # =============================================================================

--- a/quicklogic/utils/connections.py
+++ b/quicklogic/utils/connections.py
@@ -177,6 +177,7 @@ def build_tile_connections(
                 tile_loc = Loc(
                     x=loc.x + hop[0],
                     y=loc.y + hop[1],
+                    z=loc.z
                 )
 
             # Get the tile
@@ -251,8 +252,8 @@ def build_hop_connections(switchbox_types, switchbox_grid):
     # Determine the switchbox grid limits
     xs = set([loc.x for loc in switchbox_grid.keys()])
     ys = set([loc.y for loc in switchbox_grid.keys()])
-    loc_min = Loc(min(xs), min(ys))
-    loc_max = Loc(max(xs), max(ys))
+    loc_min = Loc(min(xs), min(ys), 0)
+    loc_max = Loc(max(xs), max(ys), 0)
 
     # Identify all connections that go out of switchboxes
     for dst_loc, dst_switchbox_type in switchbox_grid.items():
@@ -272,7 +273,7 @@ def build_hop_connections(switchbox_types, switchbox_grid):
                 continue
 
             # Check if we don't hop outside the FPGA grid.
-            src_loc = Loc(dst_loc.x + hop_ofs[0], dst_loc.y + hop_ofs[1])
+            src_loc = Loc(dst_loc.x + hop_ofs[0], dst_loc.y + hop_ofs[1], 0)
             if src_loc.x < loc_min.x or src_loc.x > loc_max.x:
                 continue
             if src_loc.y < loc_min.y or src_loc.y > loc_max.y:

--- a/quicklogic/utils/connections.py
+++ b/quicklogic/utils/connections.py
@@ -231,9 +231,9 @@ def build_tile_connections(
             )
 
             if sbox_pin.direction == PinDirection.OUTPUT:
-                connection = Connection(src=src, dst=dst)
+                connection = Connection(src=src, dst=dst, is_direct=False)
             if sbox_pin.direction == PinDirection.INPUT:
-                connection = Connection(src=dst, dst=src)
+                connection = Connection(src=dst, dst=src, is_direct=False)
 
             connections.append(connection)
 
@@ -322,6 +322,7 @@ def build_hop_connections(switchbox_types, switchbox_grid):
                     pin=dst_pin.name,
                     type=ConnectionType.SWITCHBOX,
                 ),
+                is_direct=False
             )
 
             connections.append(connection)
@@ -411,6 +412,8 @@ def build_gmux_qmux_connections(
                         src_cell.type, src_cell.index, "IC"
                     )
 
+                    is_direct = True
+
                 # Connect to the other cell
                 else:
                     src_loc = other_cell.loc
@@ -430,6 +433,8 @@ def build_gmux_qmux_connections(
                             src_cell.type, src_cell.index, "IZ"
                         )
 
+                    is_direct = False
+
                 # Make the connection
                 connections.append(
                     Connection(
@@ -443,6 +448,7 @@ def build_gmux_qmux_connections(
                             pin=dst_pin_name,
                             type=dst_type
                         ),
+                        is_direct=is_direct
                     )
                 )
 

--- a/quicklogic/utils/create_clkmap_csv.py
+++ b/quicklogic/utils/create_clkmap_csv.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import argparse
+import pickle
+
+from data_structs import *
+
+# =============================================================================
+
+
+def generate_clkmap_csv(connections, tile_grid):
+    """
+    Generates a map of GMUX locations for CLOCK pad locations
+    """
+    csv_lines = []
+
+    # Get connection objects representing CLOCK to GMUX, extract location of
+    # the cells
+    for connection in connections:
+
+        # Filter connections
+        if connection.is_direct is not True:
+            continue
+
+        if "CLOCK" not in connection.src.pin or \
+           "GMUX" not in connection.dst.pin:
+            continue
+
+        # Get the CLOCK tile
+        if connection.src.loc not in tile_grid:
+            print("ERROR: No tile for the connection endpoint", connection.src)
+            continue
+
+        tile = tile_grid[connection.src.loc]
+
+        # Get the CLOCK cell
+        for c in tile.cells:
+            if c.type == "CLOCK":
+                cell = c
+                break
+        else:
+            print("ERROR: No CLOCK cell in tile at {}".format(connection.src.loc))
+            continue
+
+        # Format the CSV line
+        line = [
+            cell.alias,
+            str(connection.src.loc.x),
+            str(connection.src.loc.y),
+            str(connection.src.loc.z),
+            str(connection.dst.loc.x),
+            str(connection.dst.loc.y),
+            str(connection.dst.loc.z),
+        ]
+
+        csv_lines.append(",".join(line))
+
+    return csv_lines
+
+# =============================================================================
+
+
+def main():
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        "--db",
+        type=argparse.FileType("rb"),
+        required=True,
+        help="Input VPR database file of the device"
+    )
+    parser.add_argument(
+        "-o",
+        type=argparse.FileType("w"),
+        default="clkmap.csv",
+        help="Output CLOCK to GMUX map CSV file"
+    )
+
+    args = parser.parse_args()
+
+    # Load data from the database
+    db = pickle.load(args.db)
+
+    connections = db["connections"]
+    vpr_tile_grid = db["vpr_tile_grid"]
+
+    # Generate the CSV data
+    csv_lines = generate_clkmap_csv(connections, vpr_tile_grid)
+
+    # Write the CSV file
+    args.o.write("name,src.x,src.y,src.z,dst.x,dst.y,dst.z\n")
+    args.o.write("\n".join(csv_lines) + "\n")
+
+
+# =============================================================================
+
+if __name__ == "__main__":
+    main()

--- a/quicklogic/utils/create_place_constraints.py
+++ b/quicklogic/utils/create_place_constraints.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import csv
+
+import eblif
+
+# =============================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Creates placement constraints other than IOs'
+    )
+
+    parser.add_argument(
+        "--input",
+        '-i',
+        "-I",
+        type=argparse.FileType('r'),
+        default=sys.stdin,
+        help='The input constraints place file.'
+    )
+    parser.add_argument(
+        "--output",
+        '-o',
+        "-O",
+        type=argparse.FileType('w'),
+        default=sys.stdout,
+        help='The output constraints place file.'
+    )
+    parser.add_argument(
+        "--map",
+        type=argparse.FileType('r'),
+        required=True,
+        help="Clock pinmap CSV file"
+    )
+    parser.add_argument(
+        "--blif",
+        '-b',
+        type=argparse.FileType('r'),
+        required=True,
+        help='BLIF / eBLIF file.'
+    )
+
+    args = parser.parse_args()
+
+    # Load clock map
+    clock_to_gmux = {}
+    for row in csv.DictReader(args.map):
+        name    = row["name"]
+        src_loc = (int(row["src.x"]), int(row["src.y"]), int(row["src.z"]),)
+        dst_loc = (int(row["dst.x"]), int(row["dst.y"]), int(row["dst.z"]),)
+
+        clock_to_gmux[src_loc] = (dst_loc, name)
+
+    # Load EBLIF
+    eblif_data = eblif.parse_blif(args.blif)
+
+    # Process the IO constraints file. Pass the constraints unchanged, store
+    # them.
+    io_constraints = {}
+
+    for line in args.input:
+
+        # Strip, skip comments
+        line = line.strip()
+        if line.startswith("#"):
+            continue
+
+        args.output.write(line + "\n")
+
+        # Get block and its location
+        block, x, y, z = line.split()[0:4]
+        io_constraints[block] = (int(x), int(y), int(z),)
+
+    # Analyze the BLIF netlist. Find clock inputs that go through CLOCK IOB to
+    # GMUXes.
+    clock_connections = []
+
+    IOB_CELL = ("CLOCK_CELL", "I_PAD", "O_CLK")
+    BUF_CELL = ("GMUX_IP",    "IP",    "IZ")
+
+    for inp_net in eblif_data["inputs"]["args"]:
+
+        # This one is not constrained, skip it
+        if inp_net not in io_constraints:
+            continue
+
+        # Search for a CLOCK cell connected to that net
+        for cell in eblif_data["subckt"]:
+            if cell["type"] == "subckt" and cell["args"][0] == IOB_CELL[0]:
+                pattern = "{}={}".format(IOB_CELL[1], inp_net)
+
+                try:
+                    idx = cell["args"].index(pattern)
+                    iob_cell = cell
+                    break
+                except ValueError:
+                    pass
+
+        else:
+            continue
+
+        # Get the CLOCK to GMUX net
+        for i in range(1, len(iob_cell["args"])):
+            pin, net = iob_cell["args"][i].split("=")
+
+            if pin == IOB_CELL[2]:
+                con_net = net
+                break
+
+        else:
+            continue
+
+        # Search for a GMUX connected to the CLOCK cell
+        for cell in eblif_data["subckt"]:
+            if cell["type"] == "subckt" and cell["args"][0] == BUF_CELL[0]:
+                pattern = "{}={}".format(BUF_CELL[1], con_net)
+
+                try:
+                    idx = cell["args"].index(pattern)
+                    buf_cell = cell
+                    break
+                except ValueError:
+                    pass
+        else:
+            continue
+
+        # Get the output net of the GMUX
+        for i in range(1, len(buf_cell["args"])):
+            pin, net = buf_cell["args"][i].split("=")
+
+            if pin == BUF_CELL[2]:
+                clk_net = net
+                break
+
+        else:
+            continue
+
+        # Store data
+        clock_connections.append((inp_net, iob_cell, con_net, buf_cell, clk_net))
+
+
+    # Emit constraints for GCLK cells
+    for inp_net, iob_cell, con_net, buf_cell, clk_net in clock_connections:
+
+        src_loc = io_constraints[inp_net]
+        if src_loc not in clock_to_gmux:
+            print("ERROR: No GMUX location fro input CLOCK pad for net '{}' at {}".format(inp_net, src_loc))
+            continue
+
+        dst_loc, name = clock_to_gmux[src_loc]
+
+        # FIXME: Silently assuming here that VPR will name the GMUX block as
+        # the GMUX cell in EBLIF. In order to fix that there will be a need
+        # to read & parse the packed netlist file.
+        line ="{} {} {} {} # {}\n".format(
+            buf_cell["cname"][0],
+            *dst_loc,
+            name
+        )
+        args.output.write(line)
+
+# =============================================================================
+
+if __name__ == '__main__':
+    main()

--- a/quicklogic/utils/data_import.py
+++ b/quicklogic/utils/data_import.py
@@ -185,7 +185,7 @@ def load_logic_cells(xml_placement, cellgrid, cells_library):
             x = 1 + ord(tag[0]) - ord("A")
             y = 1 + int(tag[1:])
 
-            exceptions.add(Loc(x=x, y=y))
+            exceptions.add(Loc(x=x, y=y, z=0))
 
     xml_logicmatrix = xml_logic.find("LOGICMATRIX")
     assert xml_logicmatrix is not None
@@ -197,7 +197,7 @@ def load_logic_cells(xml_placement, cellgrid, cells_library):
 
     for j in range(ny):
         for i in range(nx):
-            loc = Loc(x0 + i, y0 + j)
+            loc = Loc(x0 + i, y0 + j, 0)
 
             if loc in exceptions:
                 continue
@@ -235,7 +235,7 @@ def load_other_cells(xml_placement, cellgrid, cells_library):
 
                 for j in range(ny):
                     for i in range(nx):
-                        loc = Loc(x0 + i, y0 + j)
+                        loc = Loc(x0 + i, y0 + j, 0)
 
                         cellgrid[loc].append(
                             Cell(
@@ -251,7 +251,7 @@ def load_other_cells(xml_placement, cellgrid, cells_library):
                 x = int(xml.get("column"))
                 y = int(xml.get("row"))
 
-                loc = Loc(x, y)
+                loc = Loc(x, y, 0)
                 alias = xml.get("Alias", None)
 
                 cellgrid[loc].append(
@@ -398,7 +398,7 @@ def populate_switchboxes(xml_sbox, switchbox_grid):
 
     for y, x in itertools.product(range(ymin, ymax + 1), range(xmin,
                                                                xmax + 1)):
-        loc = Loc(x, y)
+        loc = Loc(x, y, 0)
 
         assert loc not in switchbox_grid, loc
         switchbox_grid[loc] = xml_sbox.tag
@@ -671,7 +671,7 @@ def parse_wire_mapping_table(xml_root, switchbox_grid, switchbox_types):
                 # Yield wire maps for each location
                 for y in range(row_beg, row_end + 1):
                     for x in range(col_beg, col_end + 1):
-                        yield (Loc(x=x, y=y), xml_maps)
+                        yield (Loc(x=x, y=y, z=0), xml_maps)
 
     # Process wire maps
     wire_maps = defaultdict(lambda: {})
@@ -724,13 +724,13 @@ def parse_wire_mapping_table(xml_root, switchbox_grid, switchbox_types):
 
                 # Compute location of the tile that the wire is connected to
                 if wire_hop_dir == "Top":
-                    tile_loc = Loc(x=loc.x, y=loc.y - wire_hop_len)
+                    tile_loc = Loc(x=loc.x, y=loc.y - wire_hop_len, z=0)
                 elif wire_hop_dir == "Bottom":
-                    tile_loc = Loc(x=loc.x, y=loc.y + wire_hop_len)
+                    tile_loc = Loc(x=loc.x, y=loc.y + wire_hop_len, z=0)
                 elif wire_hop_dir == "Left":
-                    tile_loc = Loc(x=loc.x - wire_hop_len, y=loc.y)
+                    tile_loc = Loc(x=loc.x - wire_hop_len, y=loc.y, z=0)
                 elif wire_hop_dir == "Right":
-                    tile_loc = Loc(x=loc.x + wire_hop_len, y=loc.y)
+                    tile_loc = Loc(x=loc.x + wire_hop_len, y=loc.y, z=0)
                 else:
                     assert False, wire_hop_dir
 
@@ -817,6 +817,7 @@ def parse_port_mapping_table(xml_root, switchbox_grid):
                     loc = Loc(
                         x=base_loc.x + dx * offset,
                         y=base_loc.y + dy * offset,
+                        z=0
                     )
 
                     # Append mapping
@@ -848,6 +849,7 @@ def parse_clock_network(xml_clock_network):
         cell_loc = Loc(
             x=int(xml_cell.attrib["column"]),
             y=int(xml_cell.attrib["row"]),
+            z=0
         )
 
         # Get the cell's pinmap

--- a/quicklogic/utils/data_import.py
+++ b/quicklogic/utils/data_import.py
@@ -20,18 +20,22 @@ from connections import hop_to_str, get_name_and_hop, is_regular_hop_wire
 
 # =============================================================================
 
-# A List of cells and their pins which are clocks
+# A List of cells and their pins which are clocks. These are relevant only for
+# cells modeled as pb_types in VPR and are used to determine whether an input
+# pin should be of type "input"/"output" or "clock".
 CLOCK_PINS = {
     "LOGIC": ("QCK", ),
-    "CLOCK": ("OP", ),
+    "CLOCK": ("IC", ),
     "GMUX": (
         "IP",
+        "IC",
         "IZ",
     ),
-    "QMUX": (
-        "QCLKIN0",
-        "HSCKIN",
-        "IZ",
+    "RAM": (
+        "CLK1_0",
+        "CLK1_1",
+        "CLK2_0",
+        "CLK2_1",
     ),
 }
 

--- a/quicklogic/utils/data_structs.py
+++ b/quicklogic/utils/data_structs.py
@@ -316,7 +316,7 @@ class ConnectionType(Enum):
 ConnectionLoc = namedtuple("ConnectionLoc", "loc pin type")
 
 # A connection within the tilegrid
-Connection = namedtuple("Connection", "src dst")
+Connection = namedtuple("Connection", "src dst is_direct")
 
 # =============================================================================
 """

--- a/quicklogic/utils/data_structs.py
+++ b/quicklogic/utils/data_structs.py
@@ -43,9 +43,10 @@ class PinSide(Enum):
 
 
 """
-This is a generic location in the tilegrid
+This is a generic location in the tilegrid. Note that it also encounters for
+the sub-tile index z.
 """
-Loc = namedtuple("Loc", "x y")
+Loc = namedtuple("Loc", "x y z")
 """
 FPGA grid quadrant.
 """

--- a/quicklogic/utils/prepare_vpr_database.py
+++ b/quicklogic/utils/prepare_vpr_database.py
@@ -532,7 +532,7 @@ def process_connections(
             )
 
         # Add the connection
-        vpr_connections.append(Connection(src=eps[0], dst=eps[1]))
+        vpr_connections.append(Connection(src=eps[0], dst=eps[1], is_direct=connection.is_direct))
 
     # Remap locations of connections that go to CLOCK pads. A physical
     # BIDIR+CLOCK tile is split into separate BIDIR and CLOCK tiles.
@@ -562,7 +562,7 @@ def process_connections(
             )
 
         # Modify the connection
-        vpr_connections[i] = Connection(src=eps[0], dst=eps[1])
+        vpr_connections[i] = Connection(src=eps[0], dst=eps[1], is_direct=connection.is_direct)
 
     # Find SFBIO connections, map their endpoints to SDIOMUX tiles
     # FIXME: This should be read from the techfine. Definition of the SDIOMUX
@@ -612,7 +612,7 @@ def process_connections(
             )
 
         # Modify the connection
-        vpr_connections[i] = Connection(src=eps[0], dst=eps[1])
+        vpr_connections[i] = Connection(src=eps[0], dst=eps[1], is_direct=connection.is_direct)
 
     # Find locations of "special" tiles
     special_tile_loc = {"ASSP": None}
@@ -646,7 +646,7 @@ def process_connections(
                 )
 
         # Modify the connection
-        vpr_connections[i] = Connection(src=eps[0], dst=eps[1])
+        vpr_connections[i] = Connection(src=eps[0], dst=eps[1], is_direct=connection.is_direct)
 
     # handle RAM and MULT locations
     ram_locations = {}
@@ -696,7 +696,7 @@ def process_connections(
             )
 
         # Modify the connection
-        vpr_connections[i] = Connection(src=eps[0], dst=eps[1])
+        vpr_connections[i] = Connection(src=eps[0], dst=eps[1], is_direct=connection.is_direct)
 
     # Handle QMUX connections. Instead of making them SWITCHBOX -> TILE convert
     # to SWITCHBOX -> CLOCK
@@ -736,7 +736,7 @@ def process_connections(
             )
 
         # Modify the connection
-        vpr_connections[i] = Connection(src=eps[0], dst=eps[1])
+        vpr_connections[i] = Connection(src=eps[0], dst=eps[1], is_direct=connection.is_direct)
 
     return vpr_connections
 

--- a/quicklogic/utils/routing_import.py
+++ b/quicklogic/utils/routing_import.py
@@ -686,7 +686,7 @@ def add_tracks_for_const_network(graph, const, tile_grid):
 
         # Populate the const node map
         for y, node in col_node_map.items():
-            const_node_map[Loc(x=x, y=y)] = node
+            const_node_map[Loc(x=x, y=y, z=0)] = node
 
     return const_node_map
 
@@ -1164,7 +1164,7 @@ def create_column_clock_tracks(graph, clock_cells, quadrants):
 
         # Populate the global clock network to switchbox access map
         for y, node in node_map.items():
-            loc = Loc(x=cell.loc.x, y=y)
+            loc = Loc(x=cell.loc.x, y=y, z=0)
 
             if cand_name not in cand_node_map:
                 cand_node_map[cand_name] = {}

--- a/quicklogic/utils/routing_import.py
+++ b/quicklogic/utils/routing_import.py
@@ -54,10 +54,12 @@ def is_direct(connection):
     """
 
     if connection.src.type == ConnectionType.TILE and \
-       connection.dst.type == ConnectionType.TILE:
+       connection.dst.type == ConnectionType.TILE and \
+       connection.is_direct is True:
         return True
 
     return False
+
 
 def is_clock(connection):
     """
@@ -69,6 +71,7 @@ def is_clock(connection):
         return True
 
     return False
+
 
 def is_local(connection):
     """
@@ -913,6 +916,7 @@ def populate_tile_connections(
 
                         connect(graph, sbox_node, src_node)
 
+
 def populate_direct_connections(
         graph, connections, connection_loc_to_node
 ):
@@ -927,11 +931,9 @@ def populate_direct_connections(
 
         # Get segment id and switch id
         if connection.src.pin.startswith("CLOCK"):
-            segment_id = graph.get_segment_id_from_name("clock")
             switch_id = graph.get_delayless_switch_id()
 
         else:
-            segment_id = graph.get_segment_id_from_name("special")
             switch_id = graph.get_delayless_switch_id()
 
         # Get tile nodes
@@ -954,20 +956,13 @@ def populate_direct_connections(
 
             continue
 
-        # Add a track connecting the two locations
-        src_track_node, dst_track_node = add_l_track(
+        # Add the edge
+        add_edge(
             graph, 
-            src_tile_node.loc.x_low, src_tile_node.loc.y_low,
-            dst_tile_node.loc.x_low, dst_tile_node.loc.y_low,
-            segment_id,
+            src_tile_node.id,
+            dst_tile_node.id,
             switch_id
         )
-
-        # Connect the track endpoints to the IPIN and OPIN
-        switch_id = graph.get_switch_id("generic")
-
-        connect(graph, src_tile_node, src_track_node, switch_id=switch_id)
-        connect(graph, dst_track_node, dst_tile_node, switch_id=switch_id)
 
 
 def populate_const_connections(graph, switchbox_models, const_node_map):

--- a/quicklogic/utils/rr_utils.py
+++ b/quicklogic/utils/rr_utils.py
@@ -74,11 +74,11 @@ def node_joint_location(node_a, node_b):
     other.
     """
 
-    loc_a1 = Loc(node_a.loc.x_low, node_a.loc.y_low)
-    loc_a2 = Loc(node_a.loc.x_high, node_a.loc.y_high)
+    loc_a1 = Loc(node_a.loc.x_low, node_a.loc.y_low,   0)
+    loc_a2 = Loc(node_a.loc.x_high, node_a.loc.y_high, 0)
 
-    loc_b1 = Loc(node_b.loc.x_low, node_b.loc.y_low)
-    loc_b2 = Loc(node_b.loc.x_high, node_b.loc.y_high)
+    loc_b1 = Loc(node_b.loc.x_low, node_b.loc.y_low,   0)
+    loc_b2 = Loc(node_b.loc.x_high, node_b.loc.y_high, 0)
 
     if loc_a1 == loc_b1:
         return loc_a1

--- a/quicklogic/utils/tile_import.py
+++ b/quicklogic/utils/tile_import.py
@@ -188,7 +188,7 @@ def make_top_level_tile(tile_type, sub_tiles, tile_types, equivalent_tiles=None)
             )
 
             # Same type, map one-to-one
-            if tile_type.upper() == site_type.upper():
+            if tile_type.upper() == site_type.upper() or site_pinmap is None:
 
                 all_pins = {
                     **tile_pinlists["clock"],

--- a/quicklogic/yosys/synth.tcl
+++ b/quicklogic/yosys/synth.tcl
@@ -22,6 +22,16 @@ techmap -map  $::env(TECHMAP_PATH)/cells_map.v
 # Map to the device specific VPR cell library
 techmap -map  $::env(DEVICE_CELLS_MAP)
 
+# Insert GMUX_PROXY after CLOCK_CELL cells
+select t:CLOCK_CELL %co1:+\[O_CLK\]
+clkbufmap -buf GMUX_PROXY IZ:IP
+select -clear
+
+# Map the GMUX_PROXY to GMUX with IS0=1'b1
+select t:GMUX_PROXY
+techmap -map  $::env(TECHMAP_PATH)/cells_map.v
+select -clear
+
 # opt_expr -undriven makes sure all nets are driven, if only by the $undef
 # net.
 opt_expr -undriven

--- a/utils/vpr_io_place.py
+++ b/utils/vpr_io_place.py
@@ -97,7 +97,7 @@ class IoPlace(object):
 
             # Both parts of the net should point to the same block
             assert len(block_names) == 1, (net_name, block_names)
-            return self.block_to_inst[list(block_name)[0]]
+            return self.block_to_inst[list(block_names)[0]]
 
         # A regular net
         else:


### PR DESCRIPTION
This pull request fixes issues with placing and routing CLOCK and GMUX cells.

GMUX cells are now modeled in VPR as 5 independent tiles hosting one GMUX each. This allows to constraint their placement so it is correct with respect to CLOCK cells.

GMUX placement constraints are generated by a new `create_place_constraints.py` utility script that scans the netlist and IO constraints.

With this pull-requests techmaps for the following cells were added/fixed: `ghsckbuff`, `ghsckibuff`, `mux4x0` and `mux8x0`.

For constraining of clock inputs to `BIDIR` to work, please use the latest Yosys plugin that handles IO cells: https://github.com/QuickLogic-Corp/yosys-symbiflow-plugins/pull/2

Also make sure to use the latest Yosys from the branch: https://github.com/antmicro/yosys/tree/quicklogic-rebased