### PR TITLE
Fix unexpected removal of ASSP cell

### DIFF
--- a/quicklogic/primitives/assp/assp.sim.v
+++ b/quicklogic/primitives/assp/assp.sim.v
@@ -1,4 +1,5 @@
 (* whitebox *)
+(* keep *)
 module ASSP (
   input         WB_CLK,
   input         WBs_ACK,


### PR DESCRIPTION
Added the `(* keep *)` attribute to the ASSP cell in VPR. This prevents Yosys from removing it after techmapping. Fixes "KeyError" issues of the test designs.