### PR TITLE
Emission of missing fasm features

### DIFF
--- a/quicklogic/primitives/clock/clock_cell.sim.v
+++ b/quicklogic/primitives/clock/clock_cell.sim.v
@@ -1,4 +1,5 @@
 (* whitebox *)
+(* FASM_FEATURES="INTERFACE.ASSP.INV.ASSPInvPortAlias" *)
 module CLOCK_CELL(I_PAD, O_CLK);
 
     (* iopad_external_pin *)


### PR DESCRIPTION
This PR fixes an issue with `CLOCK` cell not working correctly due to lack of certain bits set in bitstream.