### PR TITLE
QL: install: fix fasm_to_bit install dependecies

### DIFF
--- a/quicklogic/common/cmake/install.cmake
+++ b/quicklogic/common/cmake/install.cmake
@@ -23,6 +23,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
   list(JOIN VPR_BASE_ARGS " " VPR_BASE_ARGS)
   string(JOIN " " VPR_ARGS ${VPR_BASE_ARGS} "--route_chan_width ${ROUTE_CHAN_WIDTH}" ${VPR_ARCH_ARGS})
   get_target_property_required(FASM_TO_BIT ${ARCH} FASM_TO_BIT)
+  get_target_property_required(FASM_TO_BIT_DEPS ${ARCH} FASM_TO_BIT_DEPS)
 
   set(WRAPPERS env generate_constraints pack place route synth write_bitstream write_fasm write_jlink write_bitheader write_fasm2bels generate_fasm2bels ql_symbiflow analysis)
 
@@ -31,7 +32,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
   add_custom_target(
     "DEVICE_INSTALL_${FASM_TO_BIT_TARGET}"
     ALL
-    DEPENDS ${FASM_TO_BIT}
+    DEPENDS ${FASM_TO_BIT} ${FASM_TO_BIT_DEPS}
     )
 
   get_file_target(CELLS_SIM_TARGET ${DEFINE_QL_TOOLCHAIN_TARGET_CELLS_SIM})


### PR DESCRIPTION
Recent changes in cmake scripts seem to broke the `qlfasm` install deps. This PR is fixing it.
