### PR TITLE
Netlist optimization

### DIFF
--- a/quicklogic/common/cmake/quicklogic_device.cmake
+++ b/quicklogic/common/cmake/quicklogic_device.cmake
@@ -297,6 +297,9 @@ function(QUICKLOGIC_DEFINE_DEVICE)
         --route_chan_width 500
         --allow_dangling_combinational_nodes on
         --allowed_tiles_for_delay_model TL-LOGIC # TODO: Make this a parameter !
+        --allow_unrelated_clustering on
+        --balance_block_type_utilization on
+        --target_ext_pin_util 1.0
     )
 
   endforeach()

--- a/quicklogic/pp3/CMakeLists.txt
+++ b/quicklogic/pp3/CMakeLists.txt
@@ -1,11 +1,14 @@
 add_subdirectory(primitives)
 
-set(CELLS_MAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/techmap/cells_map.v)
-get_filename_component(FAMILY_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-set(CELLS_MAP_FILE_DEST_DIR ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/${FAMILY_NAME}/techmap/)
-
 # Copy map files to binary dir.
-file(COPY ${CELLS_MAP_FILE} DESTINATION ${CELLS_MAP_FILE_DEST_DIR})
+get_filename_component(FAMILY_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set(CELLS_MAP_DEST_DIR ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/${FAMILY_NAME}/techmap/)
+
+file(COPY "techmap/cells_map.v"  DESTINATION ${CELLS_MAP_DEST_DIR})
+file(COPY "techmap/lut2tomux4.v" DESTINATION ${CELLS_MAP_DEST_DIR})
+file(COPY "techmap/lut2tomux2.v" DESTINATION ${CELLS_MAP_DEST_DIR})
+file(COPY "techmap/lut3tomux2.v" DESTINATION ${CELLS_MAP_DEST_DIR})
+file(COPY "techmap/mux4tomux2.v" DESTINATION ${CELLS_MAP_DEST_DIR})
 
 set(CELLS_SIM_FILE ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/${FAMILY_NAME}/techmap/cells_sim.v)
 add_cells_sim_target(${CELLS_SIM_FILE} ${FAMILY_NAME})

--- a/quicklogic/pp3/techmap/lut2tomux2.v
+++ b/quicklogic/pp3/techmap/lut2tomux2.v
@@ -1,0 +1,34 @@
+// Converts a LUT2 to a mux2x0 directly if the LUT configuration allows for that.
+module LUT2(
+    input  I0,
+    input  I1,
+    output O
+);
+
+    parameter [3:0] INIT = 4'd0;
+
+    generate if (INIT == 4'b1000) begin
+        mux2x0 _TECHMAP_REPLACE_ (.A( 0), .B(I0), .S(I1), .Q(O));
+    end else if (INIT == 4'b1011) begin
+        mux2x0 _TECHMAP_REPLACE_ (.A( 1), .B(I0), .S(I1), .Q(O));
+
+//  end else if (INIT == 4'b1000) begin
+//      mux2x0 _TECHMAP_REPLACE_ (.A( 0), .B(I1), .S(I0), .Q(O));
+    end else if (INIT == 4'b1101) begin
+        mux2x0 _TECHMAP_REPLACE_ (.A( 1), .B(I1), .S(I0), .Q(O));
+
+    end else if (INIT == 4'b0010) begin
+        mux2x0 _TECHMAP_REPLACE_ (.A(I0), .B( 0), .S(I1), .Q(O));
+    end else if (INIT == 4'b1110) begin
+        mux2x0 _TECHMAP_REPLACE_ (.A(I0), .B( 1), .S(I1), .Q(O));
+
+    end else if (INIT == 4'b0100) begin
+        mux2x0 _TECHMAP_REPLACE_ (.A(I1), .B( 0), .S(I0), .Q(O));
+//  end else if (INIT == 4'b1110) begin
+//      mux2x0 _TECHMAP_REPLACE_ (.A(I1), .B( 1), .S(I0), .Q(O));
+
+    end else
+        wire _TECHMAP_FAIL_ = 1'b1;
+    endgenerate
+
+endmodule

--- a/quicklogic/pp3/techmap/lut2tomux4.v
+++ b/quicklogic/pp3/techmap/lut2tomux4.v
@@ -1,0 +1,26 @@
+// In EOS S3 / PP3 2-input LUTs are actually mapped to muxes that select from
+// 0s and 1s according to the LUT configuration. This techmap does that explicitly
+// by converting LUT2 to mux4x0.
+module LUT2 (
+  output O,
+  input  I0,
+  input  I1
+);
+  parameter [3:0] INIT = 0;
+
+  wire XA1 = INIT[0];
+  wire XA2 = INIT[1];
+  wire XB1 = INIT[2];
+  wire XB2 = INIT[3];
+
+  mux4x0 _TECHMAP_REPLACE_ (
+  .A  (XA1),
+  .B  (XA2),
+  .C  (XB1),
+  .D  (XB2),
+  .S1 (I1),
+  .S0 (I0),
+  .Q  (O)
+  );
+
+endmodule

--- a/quicklogic/pp3/techmap/lut3tomux2.v
+++ b/quicklogic/pp3/techmap/lut3tomux2.v
@@ -1,0 +1,28 @@
+// Converts a LUT3 to a mux2x0 whenever the LUT configuration allows for that.
+
+module LUT3 (
+    input  I0,
+    input  I1,
+    input  I2,
+    output O
+);
+
+    parameter [7:0] INIT = 8'd0;
+
+    generate if (INIT == 8'b1010_1100) begin
+        mux2x0 _TECHMAP_REPLACE_ (.S(I2), .A(I1), .B(I0), .Q(O));
+    end else if (INIT == 8'b1100_1010) begin
+        mux2x0 _TECHMAP_REPLACE_ (.S(I2), .B(I1), .A(I0), .Q(O));
+    end else if (INIT == 8'b1011_1000) begin
+        mux2x0 _TECHMAP_REPLACE_ (.A(I2), .S(I1), .B(I0), .Q(O));
+    end else if (INIT == 8'b1110_0010) begin
+        mux2x0 _TECHMAP_REPLACE_ (.B(I2), .S(I1), .A(I0), .Q(O));
+    end else if (INIT == 8'b1101_1000) begin
+        mux2x0 _TECHMAP_REPLACE_ (.A(I2), .B(I1), .S(I0), .Q(O));
+    end else if (INIT == 8'b1110_0100) begin
+        mux2x0 _TECHMAP_REPLACE_ (.B(I2), .A(I1), .S(I0), .Q(O));
+    end else
+        wire _TECHMAP_FAIL_ = 1'b1;
+    endgenerate
+
+endmodule

--- a/quicklogic/pp3/techmap/mux4tomux2.v
+++ b/quicklogic/pp3/techmap/mux4tomux2.v
@@ -1,0 +1,16 @@
+// This techmap splits mux4x0 into 3x mux2x0
+
+module mux4x0 (A, B, C, D, S0, S1, Q);
+    input  A, B, C, D;
+    input  S0, S1;
+    output Q;
+
+    wire q0;
+    wire q1;
+
+    mux2x0 mux0 (.A(A),  .B(B),  .S(S0), .Q(q0));
+    mux2x0 mux1 (.A(C),  .B(D),  .S(S0), .Q(q1));
+
+    mux2x0 mux2 (.A(q0), .B(q1), .S(S1), .Q(Q));
+
+endmodule

--- a/quicklogic/pp3/yosys/pack.tcl
+++ b/quicklogic/pp3/yosys/pack.tcl
@@ -1,0 +1,109 @@
+
+proc max {a b} {
+    if {$a > $b} {
+        return $a
+    } else {
+        return $b
+    }
+}
+
+proc min {a b} {
+    if {$a < $b} {
+        return $a
+    } else {
+        return $b
+    }
+}
+
+# Returns the required number of C_FRAGs to fit the design
+proc get_used_c_frag {} {
+    set used_c_frag [get_count -cells t:mux8x0 t:LUT4 t:logic_cell_macro]
+    set used_t_frag [get_count -cells t:mux4x0 t:LUT2 t:LUT3]
+
+    set used_c_frag_for_t_frag [expr int(ceil($used_t_frag  / 2.0))]
+    return [max $used_c_frag $used_c_frag_for_t_frag]
+}
+
+# Returns the required number of F_FRAGs to fit the design
+proc get_used_f_frag {} {
+    return [get_count -cells t:inv t:mux2x0 t:LUT1 t:logic_cell_macro]
+}
+
+# =============================================================================
+
+proc pack {} {
+
+    # Load the plugin that allows to retrieve cell count
+    yosys plugin -i get_count
+
+    # Maximum number of LOGIC cells in the device
+    set max_logic 891
+
+    # Target number of LOGIC cells. This is less than max to allow the VPR
+    # packet to have more freedom.
+    set target_logic [expr int($max_logic * 0.75)]
+
+    # LUT3 -> mux2x0 (replace)
+    set used_c_frag [get_used_c_frag]
+    if {$used_c_frag > $target_logic} {
+
+        # Update
+        set required_frags [expr 2 * ($used_c_frag - $target_logic)]
+        set used_f_frag [get_used_f_frag]
+        set free_f_frag [expr $target_logic - $used_f_frag]
+
+        # Try converting LUT3 to mux2x0
+        if {$free_f_frag > 0} {
+            puts "Device overfitted ($used_c_frag / $max_logic). Optimizing..."
+
+            set sel_count [min $required_frags $free_f_frag]
+            yosys techmap -map $::env(TECHMAP_PATH)/lut3tomux2.v t:LUT3 %R$sel_count
+        }
+    }
+
+    # LUT2 -> mux2x0 (replace)
+    set used_c_frag [get_used_c_frag]
+    if {$used_c_frag > $target_logic} {
+
+        # Update
+        set required_frags [expr 2 * ($used_c_frag - $target_logic)]
+        set used_f_frag [get_used_f_frag]
+        set free_f_frag [expr $target_logic - $used_f_frag]
+
+        # Try converting LUT2 to mux2x0
+        if {$free_f_frag > 0} {
+            puts "Device overfitted ($used_c_frag / $max_logic). Optimizing..."
+
+            set sel_count [min $required_frags $free_f_frag]
+            yosys techmap -map $::env(TECHMAP_PATH)/lut2tomux2.v t:LUT2 %R$sel_count
+        }
+    }
+
+    # Split mux4x0
+    set used_c_frag [get_used_c_frag]
+    if {$used_c_frag > $target_logic} {
+
+        # Update
+        set required_frags [expr 2 * ($used_c_frag - $target_logic)]
+        set used_f_frag [get_used_f_frag]
+        set free_f_frag [expr $target_logic - $used_f_frag]
+
+        # Try converting mux4x0 to 3x mux2x0
+        if {$free_f_frag >= 3} {
+            puts "Device overfitted ($used_c_frag / $max_logic). Optimizing..."
+
+            set sel_count [min $required_frags [expr int(floor($free_f_frag / 3.0))]]
+
+            # If there are not enough mux4x0 then map some LUT2 to them (these are
+            # actually equivalent)
+            set mux4_count [get_count -cells t:mux4x0]
+            if {$mux4_count < $sel_count} {
+                set map_count [expr $sel_count - $mux4_count]
+                yosys techmap -map $::env(TECHMAP_PATH)/lut2tomux4.v t:LUT2 %R$map_count
+            }
+
+            yosys techmap -map $::env(TECHMAP_PATH)/mux4tomux2.v t:mux4x0 %R$sel_count
+        }
+    }
+}
+pack

--- a/quicklogic/pp3/yosys/synth.tcl
+++ b/quicklogic/pp3/yosys/synth.tcl
@@ -6,7 +6,13 @@ read_verilog -lib $::env(TECHMAP_PATH)/cells_sim.v
 read_verilog -lib $::env(DEVICE_CELLS_SIM)
 
 # Synthesize
-synth_quicklogic 
+synth_quicklogic -family pp3 
+
+# Optimize the netlist by adaptively splitting cells that fit into C_FRAG into
+# smaller that can fit into F_FRAG.
+source $::env(symbiflow-arch-defs_SOURCE_DIR)/quicklogic/pp3/yosys/pack.tcl
+pack
+stat
 
 # Assing parameters to IO cells basing on constraints and package pinmap
 if { $::env(PCF_FILE) != "" && $::env(PINMAP_FILE) != ""} {
@@ -31,10 +37,9 @@ techmap -map  $::env(DEVICE_CELLS_MAP)
 # net.
 opt_expr -undriven
 opt_clean
-
 setundef -zero -params
-
 stat
 
+# Write output files
 write_json $::env(OUT_JSON)
 write_verilog $::env(OUT_SYNTH_V)


### PR DESCRIPTION
This pull request adds a netlist optimization stage that allows to pack large designs. Requires the Yosys script to be integrated to operate correctly: https://github.com/QuickLogic-Corp/yosys-symbiflow-plugins/pull/4

The optimization is based on mapping of excessive cells that occupy C_FRAGs into F_FRAGs. In particular:
- Mapping of `LUT2` to a single `mux2x0` whenever the LUT configuration allows it,
- Mapping of `LUT3` to a single `mux2x0` when the lookup table resembles a single 2:1 MUX,
- Splitting `mux4x0` to 3x `mux2x0` and if needed mapping `LUT2` to `mux4x0` prior to that.

The optimization is implemented as a TCL script run by Yosys. The script takes advantage of the custom `get_count` plugin to retrieve number of cells of particular type in the design. With that knowledge it is possible to determine whether mapping them to different ones would decrease the overall design size.