### PR TITLE
Use Cached Lookahead

### DIFF
--- a/quicklogic/common/cmake/quicklogic_device.cmake
+++ b/quicklogic/common/cmake/quicklogic_device.cmake
@@ -285,6 +285,7 @@ function(QUICKLOGIC_DEFINE_DEVICE)
       WIRE_EBLIF ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/passthrough.eblif
       RR_PATCH_DEPS ${DEVICE_RR_PATCH_DEPS}
       CACHE_PLACE_DELAY
+      CACHE_LOOKAHEAD
       CACHE_ARGS
         --constant_net_method route
         --clock_modeling route

--- a/quicklogic/common/utils/prepare_vpr_database.py
+++ b/quicklogic/common/utils/prepare_vpr_database.py
@@ -30,6 +30,8 @@ IGNORED_IO_CELL_TYPES = (
 
 # =============================================================================
 
+DEBUG = False
+
 
 def is_loc_within_limit(loc, limit):
     """
@@ -61,6 +63,7 @@ def is_loc_free(loc, tile_grid):
 
     return False
 
+
 # =============================================================================
 
 
@@ -89,14 +92,14 @@ def process_cells_library(cells_library):
 
             # Substitute the cell
             vpr_cells_library[cell_type] = CellType(
-                type=cell_type,
-                pins=cell_pins
+                type=cell_type, pins=cell_pins
             )
 
         # Copy the cell
         vpr_cells_library[cell_type] = cell
 
     return vpr_cells_library
+
 
 # =============================================================================
 
@@ -1182,8 +1185,8 @@ def main():
 
     # Process the tilegrid
     vpr_tile_grid, vpr_clock_cells, loc_map = process_tilegrid(
-        tile_types, phy_tile_grid, phy_clock_cells, vpr_cells_library, grid_size,
-        grid_offset, grid_limit
+        tile_types, phy_tile_grid, phy_clock_cells, vpr_cells_library,
+        grid_size, grid_offset, grid_limit
     )
 
     # Process the switchbox grid
@@ -1266,87 +1269,88 @@ def main():
         sw = add_vpr_switches_for_cell("CAND", cell_timings)
         vpr_switches.update(sw)
 
-    # DBEUG
-    print("Tile grid:")
-    xmax = max([loc.x for loc in vpr_tile_grid])
-    ymax = max([loc.y for loc in vpr_tile_grid])
-    for y in range(ymax + 1):
-        l = " {:>2}: ".format(y)
-        for x in range(xmax + 1):
-            loc = Loc(x=x, y=y, z=0)
-            if loc not in vpr_tile_grid:
-                l += " "
-            elif vpr_tile_grid[loc] is not None:
-                tile_type = vpr_tile_types[vpr_tile_grid[loc].type]
-                label = sorted(list(tile_type.cells.keys()))[0][0].upper()
-                l += label
-            else:
-                l += "."
-        print(l)
+    if DEBUG:
+        # DBEUG
+        print("Tile grid:")
+        xmax = max([loc.x for loc in vpr_tile_grid])
+        ymax = max([loc.y for loc in vpr_tile_grid])
+        for y in range(ymax + 1):
+            l = " {:>2}: ".format(y)
+            for x in range(xmax + 1):
+                loc = Loc(x=x, y=y, z=0)
+                if loc not in vpr_tile_grid:
+                    l += " "
+                elif vpr_tile_grid[loc] is not None:
+                    tile_type = vpr_tile_types[vpr_tile_grid[loc].type]
+                    label = sorted(list(tile_type.cells.keys()))[0][0].upper()
+                    l += label
+                else:
+                    l += "."
+            print(l)
 
-    # DBEUG
-    print("Tile capacity / sub-tile count")
-    xmax = max([loc.x for loc in vpr_tile_grid])
-    ymax = max([loc.y for loc in vpr_tile_grid])
-    for y in range(ymax + 1):
-        l = " {:>2}: ".format(y)
-        for x in range(xmax + 1):
+        # DBEUG
+        print("Tile capacity / sub-tile count")
+        xmax = max([loc.x for loc in vpr_tile_grid])
+        ymax = max([loc.y for loc in vpr_tile_grid])
+        for y in range(ymax + 1):
+            l = " {:>2}: ".format(y)
+            for x in range(xmax + 1):
 
-            tiles = {loc: tile for loc, tile in vpr_tile_grid.items() if \
-                     loc.x == x and loc.y == y}
-            count = len([t for t in tiles.values() if t is not None])
+                tiles = {loc: tile for loc, tile in vpr_tile_grid.items() if \
+                         loc.x == x and loc.y == y}
+                count = len([t for t in tiles.values() if t is not None])
 
-            if len(tiles) == 0:
-                l += " "
-            elif count == 0:
-                l += "."
-            else:
-                l += "{:X}".format(count)
+                if len(tiles) == 0:
+                    l += " "
+                elif count == 0:
+                    l += "."
+                else:
+                    l += "{:X}".format(count)
 
-        print(l)
+            print(l)
 
-    # DEBUG
-    print("Switchbox grid:")
-    xmax = max([loc.x for loc in vpr_switchbox_grid])
-    ymax = max([loc.y for loc in vpr_switchbox_grid])
-    for y in range(ymax + 1):
-        l = " {:>2}: ".format(y)
-        for x in range(xmax + 1):
-            loc = Loc(x=x, y=y, z=0)
-            if loc not in vpr_switchbox_grid:
-                l += " "
-            elif vpr_switchbox_grid[loc] is not None:
-                l += "X"
-            else:
-                l += "."
-        print(l)
+        # DEBUG
+        print("Switchbox grid:")
+        xmax = max([loc.x for loc in vpr_switchbox_grid])
+        ymax = max([loc.y for loc in vpr_switchbox_grid])
+        for y in range(ymax + 1):
+            l = " {:>2}: ".format(y)
+            for x in range(xmax + 1):
+                loc = Loc(x=x, y=y, z=0)
+                if loc not in vpr_switchbox_grid:
+                    l += " "
+                elif vpr_switchbox_grid[loc] is not None:
+                    l += "X"
+                else:
+                    l += "."
+            print(l)
 
-    # DBEUG
-    print("Route-through global clock cells:")
-    xmax = max([loc.x for loc in vpr_tile_grid])
-    ymax = max([loc.y for loc in vpr_tile_grid])
-    for y in range(ymax + 1):
-        l = " {:>2}: ".format(y)
-        for x in range(xmax + 1):
-            loc = Loc(x=x, y=y, z=0)
+        # DBEUG
+        print("Route-through global clock cells:")
+        xmax = max([loc.x for loc in vpr_tile_grid])
+        ymax = max([loc.y for loc in vpr_tile_grid])
+        for y in range(ymax + 1):
+            l = " {:>2}: ".format(y)
+            for x in range(xmax + 1):
+                loc = Loc(x=x, y=y, z=0)
 
-            for cell in vpr_clock_cells.values():
-                if cell.loc == loc:
-                    l += cell.name[0].upper()
-                    break
-            else:
-                l += "."
-        print(l)
+                for cell in vpr_clock_cells.values():
+                    if cell.loc == loc:
+                        l += cell.name[0].upper()
+                        break
+                else:
+                    l += "."
+            print(l)
 
-    # DEBUG
-    print("VPR Segments:")
-    for s in vpr_segments.values():
-        print("", s)
+        # DEBUG
+        print("VPR Segments:")
+        for s in vpr_segments.values():
+            print("", s)
 
-    # DEBUG
-    print("VPR Switches:")
-    for s in vpr_switches.values():
-        print("", s)
+        # DEBUG
+        print("VPR Switches:")
+        for s in vpr_switches.values():
+            print("", s)
 
     # Prepare the VPR database and write it
     db_root = {

--- a/quicklogic/pp3/primitives/ram/make_rams.py
+++ b/quicklogic/pp3/primitives/ram/make_rams.py
@@ -8,6 +8,42 @@ import lxml.etree as ET
 import sdf_timing.sdfparse
 from sdf_timing.utils import get_scale_seconds
 
+from termcolor import colored
+
+
+def log(ltype, message, outdesc=None):
+    """Prints log messages.
+
+    Parameters
+    ----------
+    ltype: str
+        Log type, can be INFO, WARNING, ERROR
+    message: str
+        Log message
+    """
+
+    LOGLEVELS = ["INFO", "WARNING", "ERROR", "ALL"]
+    SUPPRESSBELOW = "ERROR"
+
+    if ltype not in LOGLEVELS[:-1]:
+        return
+
+    dat = {
+        "INFO": (0, "green"),
+        "WARNING": (1, "yellow"),
+        "ERROR": (2, "red"),
+        "ALL": (3, "black")
+    }
+
+    if dat[ltype][0] >= dat[SUPPRESSBELOW][0]:
+        print(colored("{}: {}".format(ltype, message), dat[ltype][1]))
+        if outdesc:
+            print(
+                colored("{}: {}".format(ltype, message), dat[ltype][1]),
+                file=outdesc
+            )
+
+
 # =============================================================================
 
 # RAM 2x1 ports, their widths and associated clocks.
@@ -709,9 +745,11 @@ def make_pb_type(
             else:
                 delay = 1e-10
                 stats["missing_timings"] += 1
-                print(
-                    "WARNING: No setup timing for '{}'->'{}' for pb_type '{}'".
-                    format(alias + suffix, assoc_clock, pb_name)
+                log(
+                    "WARNING",
+                    "No setup timing for '{}'->'{}' for pb_type '{}'".format(
+                        alias + suffix, assoc_clock, pb_name
+                    )
                 )
 
             stats["total_timings"] += 1
@@ -742,9 +780,11 @@ def make_pb_type(
             else:
                 delay = 1e-10
                 stats["missing_timings"] += 1
-                print(
-                    "WARNING: No hold timing for '{}'->'{}' for pb_type '{}'".
-                    format(alias + suffix, assoc_clock, pb_name)
+                log(
+                    "WARNING",
+                    "No hold timing for '{}'->'{}' for pb_type '{}'".format(
+                        alias + suffix, assoc_clock, pb_name
+                    )
                 )
 
             stats["total_timings"] += 1
@@ -791,9 +831,10 @@ def make_pb_type(
                 delay_min = 1e-10
                 delay_max = 1e-10
                 stats["missing_timings"] += 1
-                print(
-                    "WARNING: No \"clock to Q\" timing for '{}'->'{}' for pb_type '{}'"
-                    .format(assoc_clock, alias + suffix, pb_name)
+                log(
+                    "WARNING",
+                    "No \"clock to Q\" timing for '{}'->'{}' for pb_type '{}'".
+                    format(assoc_clock, alias + suffix, pb_name)
                 )
 
             stats["total_timings"] += 1


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to add the cached lookahead. By using with the QuickLogic flow, I have seen the lookahead generation overhead which can be simply reduced to zero if we use the cached lookahead.

This should automatically apply to the install package as well.
