### PR TITLE
ql: cmake: fix target dependencies to build pin map and clk map csv

### DIFF
--- a/quicklogic/common/cmake/quicklogic_device.cmake
+++ b/quicklogic/common/cmake/quicklogic_device.cmake
@@ -1,7 +1,7 @@
 function(QUICKLOGIC_DEFINE_DEVICE_TYPE)
   # ~~~
   # QUICKLOGIC_DEFINE_DEVICE_TYPE(
-  #   FAMILY <family>  
+  #   FAMILY <family>
   #   ARCH <arch>
   #   DEVICE <device>
   #   PACKAGES <package> <package> ...
@@ -64,7 +64,7 @@ function(QUICKLOGIC_DEFINE_DEVICE_TYPE)
 
   get_target_property_required(QUICKLOGIC_TIMINGS_IMPORTER env QUICKLOGIC_TIMINGS_IMPORTER)
   get_target_property_required(QUICKLOGIC_TIMINGS_IMPORTER_TARGET env QUICKLOGIC_TIMINGS_IMPORTER_TARGET)
-  
+
   # TODO: How to handle different timing cases that depend on a cell config?
   # For example BIDIR cells have different timings for different voltages.
   #
@@ -123,8 +123,7 @@ function(QUICKLOGIC_DEFINE_DEVICE_TYPE)
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${VPR_DB_FILE}
     COMMAND ${PYTHON3} ${PREPARE_VPR_DATABASE}
       --phy-db ${PHY_DB_FILE}
-      --vpr-db ${VPR_DB_FILE}
-      --sdf-dir ${SDF_TIMING_DIR} 
+      --sdf-dir ${SDF_TIMING_DIR} > ${VPR_DB_FILE}
       ${GRID_LIMIT_ARGS}
     DEPENDS ${PHY_DB_FILE} sdf_timing ${SDF_FILE_TARGETS} ${PREPARE_VPR_DATABASE} ${PYTHON3_TARGET}
   )

--- a/quicklogic/common/utils/prepare_vpr_database.py
+++ b/quicklogic/common/utils/prepare_vpr_database.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import pickle
+import sys
 import itertools
 import re
 import os
@@ -1102,12 +1103,6 @@ def main():
         help="A directory with SDF timing files"
     )
     parser.add_argument(
-        "--vpr-db",
-        type=str,
-        default="vpr_database.pickle",
-        help="Output VPR database file"
-    )
-    parser.add_argument(
         "--grid-limit",
         type=str,
         default=None,
@@ -1369,8 +1364,7 @@ def main():
         "switches": list(vpr_switches.values()),
     }
 
-    with open(args.vpr_db, "wb") as fp:
-        pickle.dump(db_root, fp, protocol=3)
+    pickle.dump(db_root, sys.stdout.buffer, protocol=3)
 
 
 # =============================================================================


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Travis CI reports a failure during the clkmap.csv file generation: 

```
Processing timing data...
[ 66%] Built target file_quicklogic_pp3_devices_ql-eos-s3-virt_db_vpr.pickle
Scanning dependencies of target file_quicklogic_pp3_chandalar_clkmap.csv
[ 66%] Generating chandalar_clkmap.csv
Traceback (most recent call last):
  File "/home/travis/build/QuickLogic-Corp/symbiflow-arch-defs/quicklogic/common/utils/create_clkmap_csv.py", line 107, in <module>
    main()
  File "/home/travis/build/QuickLogic-Corp/symbiflow-arch-defs/quicklogic/common/utils/create_clkmap_csv.py", line 91, in main
    db = pickle.load(args.db)
EOFError: Ran out of input
```

The `EOFError: Ran out of input` likely means that the `vpr_db.pickle` file is empty, therefore it suggests a concurrency issue in running the make targets.

With this PR this should be solved as the dependency on the pinmap and clkmap file is on the file target of the vpr_db.pickle file rather than on the file itself.