### PR TITLE
Use ninja build

### DIFF
--- a/.github/travis/common.sh
+++ b/.github/travis/common.sh
@@ -63,7 +63,7 @@ function make_target() {
 
   start_section "symbiflow.$target" "$2"
   make_status=0
-  make -k -j${MAKE_JOBS} $target || make_status=$?
+  ninja -j${MAKE_JOBS} $target || make_status=$?
   echo "check make status b4: $make_status, make jobs ${MAKE_JOBS}"
   end_section "symbiflow.$target"
   echo "check make status after: $make_status, make jobs ${MAKE_JOBS}"
@@ -71,7 +71,7 @@ function make_target() {
   # When the build fails, produce the failure output in a clear way
   if [ ${MAKE_JOBS} -ne 1 -a $make_status -ne 0 ]; then
     start_section "symbiflow.failure" "${RED}Build failure output..${NC}"
-    make -j1 $target
+    ninja -j1 $target
     end_section "symbiflow.failure"
     exit 1
   else

--- a/.github/travis/script.sh
+++ b/.github/travis/script.sh
@@ -6,7 +6,7 @@ set -e
 $SPACER
 
 start_section "symbiflow.configure_cmake" "Configuring CMake (make env)"
-make env
+make env CMAKE_FLAGS="-GNinja"
 cd build
 end_section "symbiflow.configure_cmake"
 
@@ -32,16 +32,7 @@ $SPACER
 
 echo "----------------------------------------"
 (
-    cd quicklogic/pp3/tests
     make_target all_quick_tests "Building all quick targets"
-)
-echo "----------------------------------------"
-
-$SPACER
-
-echo "----------------------------------------"
-(
-    make_target all_ql_tests "Building all quick logic tests"
 )
 echo "----------------------------------------"
 

--- a/quicklogic/common/cmake/quicklogic_device.cmake
+++ b/quicklogic/common/cmake/quicklogic_device.cmake
@@ -1,7 +1,7 @@
 function(QUICKLOGIC_DEFINE_DEVICE_TYPE)
   # ~~~
   # QUICKLOGIC_DEFINE_DEVICE_TYPE(
-  #   FAMILY <family>
+  #   FAMILY <family>  
   #   ARCH <arch>
   #   DEVICE <device>
   #   PACKAGES <package> <package> ...
@@ -64,7 +64,7 @@ function(QUICKLOGIC_DEFINE_DEVICE_TYPE)
 
   get_target_property_required(QUICKLOGIC_TIMINGS_IMPORTER env QUICKLOGIC_TIMINGS_IMPORTER)
   get_target_property_required(QUICKLOGIC_TIMINGS_IMPORTER_TARGET env QUICKLOGIC_TIMINGS_IMPORTER_TARGET)
-
+  
   # TODO: How to handle different timing cases that depend on a cell config?
   # For example BIDIR cells have different timings for different voltages.
   #
@@ -123,7 +123,8 @@ function(QUICKLOGIC_DEFINE_DEVICE_TYPE)
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${VPR_DB_FILE}
     COMMAND ${PYTHON3} ${PREPARE_VPR_DATABASE}
       --phy-db ${PHY_DB_FILE}
-      --sdf-dir ${SDF_TIMING_DIR} > ${VPR_DB_FILE}
+      --vpr-db ${VPR_DB_FILE}
+      --sdf-dir ${SDF_TIMING_DIR} 
       ${GRID_LIMIT_ARGS}
     DEPENDS ${PHY_DB_FILE} sdf_timing ${SDF_FILE_TARGETS} ${PREPARE_VPR_DATABASE} ${PYTHON3_TARGET}
   )

--- a/quicklogic/common/utils/prepare_vpr_database.py
+++ b/quicklogic/common/utils/prepare_vpr_database.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import pickle
-import sys
 import itertools
 import re
 import os
@@ -1103,6 +1102,12 @@ def main():
         help="A directory with SDF timing files"
     )
     parser.add_argument(
+        "--vpr-db",
+        type=str,
+        default="vpr_database.pickle",
+        help="Output VPR database file"
+    )
+    parser.add_argument(
         "--grid-limit",
         type=str,
         default=None,
@@ -1364,7 +1369,8 @@ def main():
         "switches": list(vpr_switches.values()),
     }
 
-    pickle.dump(db_root, sys.stdout.buffer, protocol=3)
+    with open(args.vpr_db, "wb") as fp:
+        pickle.dump(db_root, fp, protocol=3)
 
 
 # =============================================================================


### PR DESCRIPTION
This PR reverts the changes that tried to solve the multi-threaded travis build.

This moves the buildsystem to use ninja instead of make. Ninja handles dependencies in a more robust way, therefore it might solve the issue properly. 