### PR TITLE
WIP/DNM: ql: timings: fix bels definition for pp3

### DIFF
--- a/quicklogic/pp3/ql-pp3e-bels.json
+++ b/quicklogic/pp3/ql-pp3e-bels.json
@@ -113,12 +113,19 @@
     "GMUX": {
         "gmux": {
             "IP": [
-                "GMUX_IS0_EQ_0.GMUX",
-                "GMUX_IS0_EQ_1.GMUX"
+                "GMUX.GMUX",
+                "GMUX.GMUX"
             ],
             "IC": [
-                "GMUX_IS0_EQ_0.GMUX",
-                "GMUX_IS0_EQ_1.GMUX"
+                "GMUX.GMUX",
+                "GMUX.GMUX"
+            ]
+        }
+    },
+    "CLOCK": {
+        "clock_buf": {
+            "CLOCK": [
+                "CLOCK.CLOCK"
             ]
         }
     }


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is an initial fix for the timing bels for the PP3 architecture.

While running the ql-pp3 architecture build, I discovered issues with the timing sdf import, for which some of the hold timings were not present in the SDF, causing the timing updates in the architecture to fail.

This PR depends on https://github.com/QuickLogic-Corp/quicklogic-timings-importer/pull/2. With the patch to the quicklogic-timings-importer, the SDF will contain also zero-valued delays. This mainly because some of the LOGIC timings do have zero-valued `hold` specification in the liberty files, causing the hold timings to be completely discarded, with the result of causing issues when importing them in the arch.timing.xml.