### PR TITLE
io_place: skip nets with no blocks

### DIFF
--- a/quicklogic/common/utils/create_ioplace.py
+++ b/quicklogic/common/utils/create_ioplace.py
@@ -114,6 +114,8 @@ def main():
         inst = io_place.get_top_level_block_instance_for_net(
             pcf_constraint.net
         )
+        if inst is None:
+            continue
 
         match = BLOCK_INSTANCE_RE.match(inst)
         assert match is not None, inst

--- a/utils/vpr_io_place.py
+++ b/utils/vpr_io_place.py
@@ -102,8 +102,11 @@ class IoPlace(object):
 
         # A regular net
         else:
-            block_name = self.net_to_block[net_name]
-            return self.block_to_inst[block_name]
+            if net_name in self.net_to_block:
+                block_name = self.net_to_block[net_name]
+                return self.block_to_inst[block_name]
+            else:
+                return None
 
     def constrain_net(self, net_name, loc, comment=""):
         assert len(loc) == 3


### PR DESCRIPTION
This can happen if considered net is e.g. not connected top level input, or the module input is driven by a constant.

This PR fixes `1. IO placement script failing to find a net` in #97