### PR TITLE
Fix GMUX model

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/SymbiFlow/vtr-xml-utils.git
 [submodule "third_party/python-symbiflow-v2x"]
 	path = third_party/python-symbiflow-v2x
-	url = ../python-symbiflow-v2x.git
+	url = https://github.com/QuickLogic-Corp/python-symbiflow-v2x
 [submodule "third_party/quicklogic-fasm-utils"]
 	path = quicklogic/utils/fasm-utils
 	url = ../quicklogic-fasm-utils.git

--- a/quicklogic/pp3/primitives/gmux/gmux_ic.sim.v
+++ b/quicklogic/pp3/primitives/gmux/gmux_ic.sim.v
@@ -2,6 +2,7 @@
 (* FASM_FEATURES="I_invblock.I_J0.ZINV.IS0;I_invblock.I_J1.ZINV.IS1;I_invblock.I_J2.ZINV.IS0;I_invblock.I_J3.ZINV.IS0;I_invblock.I_J4.ZINV.IS1" *)
 module GMUX_IC (IC, IS0, IZ);
 
+    (* CLOCK, NO_COMB=0 *)
     input  wire IC;
     input  wire IS0;
 

--- a/quicklogic/pp3/primitives/gmux/gmux_ip.sim.v
+++ b/quicklogic/pp3/primitives/gmux/gmux_ip.sim.v
@@ -2,7 +2,9 @@
 (* FASM_FEATURES="I_invblock.I_J0.ZINV.IS0;I_invblock.I_J1.ZINV.IS1;I_invblock.I_J2.ZINV.IS0;I_invblock.I_J3.ZINV.IS0;I_invblock.I_J4.ZINV.IS1" *)
 module GMUX_IP (IP, IC, IS0, IZ);
 
+    (* CLOCK, NO_COMB=0 *)
     input  wire IP;
+    (* CLOCK, NO_COMB=0 *)
     input  wire IC;
     input  wire IS0;
 


### PR DESCRIPTION
This PR fixes the GMUX model so it is treated by VPR as a clock buffer cell. This makes VPR include its timing in the final timing report. Fixes https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/68