### PR TITLE
ql: install: remove un-needed scripts that are isntalled in conda

### DIFF
--- a/quicklogic/common/cmake/install.cmake
+++ b/quicklogic/common/cmake/install.cmake
@@ -11,29 +11,14 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
     "${ARGN}"
   )
 
-  get_target_property_required(VPR env VPR)
-  get_target_property(VPR_TARGET env VPR_TARGET)
-  get_target_property_required(GENFASM env GENFASM)
-  get_target_property(GENFASM_TARGET env GENFASM_TARGET)
-
   set(FAMILY ${DEFINE_QL_TOOLCHAIN_TARGET_FAMILY})
   set(ARCH ${DEFINE_QL_TOOLCHAIN_TARGET_ARCH})
   set(VPR_ARCH_ARGS ${DEFINE_QL_TOOLCHAIN_TARGET_VPR_ARCH_ARGS})
   set(ROUTE_CHAN_WIDTH ${DEFINE_QL_TOOLCHAIN_TARGET_ROUTE_CHAN_WIDTH})
   list(JOIN VPR_BASE_ARGS " " VPR_BASE_ARGS)
   string(JOIN " " VPR_ARGS ${VPR_BASE_ARGS} "--route_chan_width ${ROUTE_CHAN_WIDTH}" ${VPR_ARCH_ARGS})
-  get_target_property_required(FASM_TO_BIT ${ARCH} FASM_TO_BIT)
-  get_target_property_required(FASM_TO_BIT_DEPS ${ARCH} FASM_TO_BIT_DEPS)
 
   set(WRAPPERS env generate_constraints pack place route synth write_bitstream write_fasm write_jlink write_bitheader write_fasm2bels generate_fasm2bels ql_symbiflow analysis)
-
-  get_file_target(FASM_TO_BIT_TARGET ${FASM_TO_BIT})
-  # Add fasm2bit to all deps, so it is installed with make install
-  add_custom_target(
-    "DEVICE_INSTALL_${FASM_TO_BIT_TARGET}"
-    ALL
-    DEPENDS ${FASM_TO_BIT} ${FASM_TO_BIT_DEPS}
-    )
 
   get_file_target(CELLS_SIM_TARGET ${DEFINE_QL_TOOLCHAIN_TARGET_CELLS_SIM})
   # Add cells.sim to all deps, so it is installed with make install
@@ -59,13 +44,6 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
           PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
 
   # install python scripts
-  install(FILES ${FASM_TO_BIT}
-          DESTINATION bin/python
-          PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
-
-  install(DIRECTORY ${symbiflow-arch-defs_SOURCE_DIR}/third_party/fasm
-          DESTINATION bin/python)
-
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/split_inouts.py
           DESTINATION bin/python
           PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to remove fasm and qlfasm scripts from the python install dir when packaging the toolchain.

Those scripts and functionalities can be installed using conda, instead of having them copied within the `/bin/python/` dir.

Fixes https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/96