### PR TITLE
Fixe QMUX handling in fasm2bels

### DIFF
--- a/quicklogic/pp3/tests/gclk_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/gclk_counter/CMakeLists.txt
@@ -15,6 +15,5 @@ add_jlink_output(
 
 add_dependencies(all_ql_tests gclk_counter-ql-chandalar_bit)
 add_dependencies(all_ql_tests gclk_counter-ql-chandalar_jlink)
-#add_dependencies(all_quick_tests gclk_counter-ql-chandalar_analysis)
-#add_dependencies(gclk_counter-ql-chandalar_analysis gclk_counter-ql-chandalar_bit_v)
-
+add_dependencies(all_quick_tests gclk_counter-ql-chandalar_analysis)
+add_dependencies(gclk_counter-ql-chandalar_analysis gclk_counter-ql-chandalar_bit_v)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/camif/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/camif/CMakeLists.txt
@@ -16,5 +16,5 @@ add_jlink_output(
 
 add_dependencies(all_ql_tests camif-ql-chandalar_bit)
 add_dependencies(all_ql_tests camif-ql-chandalar_jlink)
-#add_dependencies(all_quick_tests camif-ql-chandalar_analysis)
-#add_dependencies(camif-ql-chandalar_analysis camif-ql-chandalar_bit_v)
+add_dependencies(all_quick_tests camif-ql-chandalar_analysis)
+add_dependencies(camif-ql-chandalar_analysis camif-ql-chandalar_bit_v)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/clock_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/clock_test/CMakeLists.txt
@@ -15,6 +15,5 @@ add_jlink_output(
 
 add_dependencies(all_ql_tests clock_test-ql-chandalar_bit)
 add_dependencies(all_ql_tests clock_test-ql-chandalar_jlink)
-#add_dependencies(all_quick_tests clock_test-ql-chandalar_analysis)
-#add_dependencies(clock_test-ql-chandalar_analysis clock_test-ql-chandalar_bit_v)
-
+add_dependencies(all_quick_tests clock_test-ql-chandalar_analysis)
+add_dependencies(clock_test-ql-chandalar_analysis clock_test-ql-chandalar_bit_v)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/fifo_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/fifo_test/CMakeLists.txt
@@ -21,7 +21,5 @@ add_jlink_output(
 
 add_dependencies(all_ql_tests fifo_test-ql-chandalar_bit)
 add_dependencies(all_ql_tests fifo_test-ql-chandalar_jlink)
-#add_dependencies(all_quick_tests fifo_test-ql-chandalar_analysis)
-#add_dependencies(fifo_test-ql-chandalar_analysis fifo_test-ql-chandalar_bit_v)
-
-
+add_dependencies(all_quick_tests fifo_test-ql-chandalar_analysis)
+add_dependencies(fifo_test-ql-chandalar_analysis fifo_test-ql-chandalar_bit_v)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/ram_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/ram_test/CMakeLists.txt
@@ -22,7 +22,5 @@ add_jlink_output(
 
 add_dependencies(all_ql_tests ram_test-ql-chandalar_bit)
 add_dependencies(all_ql_tests ram_test-ql-chandalar_jlink)
-#add_dependencies(all_quick_tests ram_test-ql-chandalar_analysis)
-#add_dependencies(ram_test-ql-chandalar_analysis ram_test-ql-chandalar_bit_v)
-
-
+add_dependencies(all_quick_tests ram_test-ql-chandalar_analysis)
+add_dependencies(ram_test-ql-chandalar_analysis ram_test-ql-chandalar_bit_v)

--- a/quicklogic/pp3/tests/soc_clocks/CMakeLists.txt
+++ b/quicklogic/pp3/tests/soc_clocks/CMakeLists.txt
@@ -15,8 +15,8 @@ add_jlink_output(
 
 add_dependencies(all_ql_tests soc_clocks-ql-chandalar_bit)
 add_dependencies(all_ql_tests soc_clocks-ql-chandalar_jlink)
-#add_dependencies(all_quick_tests soc_clocks-ql-chandalar_analysis)
-#add_dependencies(soc_clocks-ql-chandalar_analysis soc_clocks-ql-chandalar_bit_v)
+add_dependencies(all_quick_tests soc_clocks-ql-chandalar_analysis)
+add_dependencies(soc_clocks-ql-chandalar_analysis soc_clocks-ql-chandalar_bit_v)
 
 
 add_file_target(FILE quickfeather.pcf)


### PR DESCRIPTION
This PR fixes `QMUX` input handling in fasm2bels. Solves https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/103