### PR TITLE
Fix for pack.tcl in installed toolchain

### DIFF
--- a/quicklogic/common/cmake/install.cmake
+++ b/quicklogic/common/cmake/install.cmake
@@ -148,6 +148,10 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
   install(FILES  ${DEFINE_QL_TOOLCHAIN_TARGET_CONV_SCRIPT} ${DEFINE_QL_TOOLCHAIN_TARGET_SYNTH_SCRIPT}
     DESTINATION share/quicklogic)
 
+  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/yosys/pack.tcl
+	  DESTINATION share/quicklogic
+          PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
+
 endfunction()
 
 function(DEFINE_QL_DEVICE_CELLS_INSTALL_TARGET)

--- a/quicklogic/pp3/yosys/synth.tcl
+++ b/quicklogic/pp3/yosys/synth.tcl
@@ -10,7 +10,9 @@ synth_quicklogic -family pp3
 
 # Optimize the netlist by adaptively splitting cells that fit into C_FRAG into
 # smaller that can fit into F_FRAG.
-source $::env(symbiflow-arch-defs_SOURCE_DIR)/quicklogic/pp3/yosys/pack.tcl
+set mypath [ file dirname [ file normalize [ info script ] ] ]
+source "$mypath/pack.tcl"
+
 pack
 stat
 


### PR DESCRIPTION
Fixed invocation of pack.tcl and added it as a file to be installed. Fixes https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/122