### PR TITLE
Added missing EQN parameter to LUT techmaps

### DIFF
--- a/quicklogic/pp3/techmap/lut2tomux2.v
+++ b/quicklogic/pp3/techmap/lut2tomux2.v
@@ -6,6 +6,7 @@ module LUT2(
 );
 
     parameter [3:0] INIT = 4'd0;
+    parameter EQN = "(I0)";
 
     generate if (INIT == 4'b1000) begin
         mux2x0 _TECHMAP_REPLACE_ (.A( 0), .B(I0), .S(I1), .Q(O));

--- a/quicklogic/pp3/techmap/lut2tomux4.v
+++ b/quicklogic/pp3/techmap/lut2tomux4.v
@@ -7,6 +7,7 @@ module LUT2 (
   input  I1
 );
   parameter [3:0] INIT = 0;
+  parameter EQN = "(I0)";
 
   wire XA1 = INIT[0];
   wire XA2 = INIT[1];

--- a/quicklogic/pp3/techmap/lut3tomux2.v
+++ b/quicklogic/pp3/techmap/lut3tomux2.v
@@ -8,6 +8,7 @@ module LUT3 (
 );
 
     parameter [7:0] INIT = 8'd0;
+    parameter EQN = "(I0)";
 
     generate if (INIT == 8'b1010_1100) begin
         mux2x0 _TECHMAP_REPLACE_ (.S(I2), .A(I1), .B(I0), .Q(O));


### PR DESCRIPTION
This PR adds missing `EQN` parameter to techmaps responsible for converting LUTs to MUXes