### PR TITLE
SDIOMUX support fix

### DIFF
--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -381,7 +381,7 @@ BUILDDIR := build\n\n\
 all: \${BUILDDIR}/\${TOP}.bit\n\
 \n\
 \${BUILDDIR}/\${TOP}.eblif: \${VERILOG}\n\
-	cd \${BUILDDIR} && synth -t \${TOP} -v \${VERILOG} -d \${DEVICE} 2>&1 > $LOG_FILE\n\
+	cd \${BUILDDIR} && synth -t \${TOP} -v \${VERILOG} -d \${DEVICE} -p \${PCF} -P \${PART} 2>&1 > $LOG_FILE\n\
 \n\
 \${BUILDDIR}/\${TOP}.net: \${BUILDDIR}/\${TOP}.eblif\n\
 	cd \${BUILDDIR} && pack -e \${TOP}.eblif -d \${DEVICE} -s \${SDC} 2>&1 > $LOG_FILE\n\


### PR DESCRIPTION
This pull request fixes support for SDIOMUX pads in the installed toolchain. Fixes https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/issues/17