### PR TITLE
Fixes for quicklogic_testsuite designs

### DIFF
--- a/quicklogic/pp3/tests/quicklogic_testsuite/cavlc_top/chandalar.pcf
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/cavlc_top/chandalar.pcf
@@ -12,6 +12,7 @@ set_io rbsp(5) B4
 set_io rbsp(6) A4
 set_io rbsp(7) C5
 set_io rbsp(8) B5
+set_io rbsp(9) D6
 
 set_io nC(0) A5
 set_io nC(1) C6
@@ -24,6 +25,7 @@ set_io max_coeff_num(0) G8
 set_io max_coeff_num(1) H7
 set_io max_coeff_num(2) G7
 set_io max_coeff_num(3) H6
+set_io max_coeff_num(4) E3
 
 set_io coeff(0) G6
 set_io coeff(1) F7
@@ -34,3 +36,18 @@ set_io coeff(5) F5
 set_io coeff(6) F4
 set_io coeff(7) G4
 set_io coeff(8) H4
+
+set_io idle F3
+set_io valid F2
+
+set_io len_comb(0) H3
+set_io len_comb(1) G2
+set_io len_comb(2) E2
+set_io len_comb(3) H2
+set_io len_comb(4) D2
+
+set_io TotalCoeff(0) F1
+set_io TotalCoeff(1) H1
+set_io TotalCoeff(2) D1
+set_io TotalCoeff(3) E1
+set_io TotalCoeff(4) G1

--- a/quicklogic/pp3/tests/quicklogic_testsuite/iir/chandalar.pcf
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/iir/chandalar.pcf
@@ -29,6 +29,7 @@ set_io params(6)     F7
 set_io params(7)     F6
 set_io params(8)     H5
 set_io params(9)     G5
+set_io params(10)    G2
 set_io params(11)    F5
 set_io params(12)    F4
 set_io params(13)    G4

--- a/quicklogic/pp3/tests/quicklogic_testsuite/sha256_fullfit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/sha256_fullfit/CMakeLists.txt
@@ -1,11 +1,11 @@
-add_file_target(FILE sha1.v SCANNER_TYPE verilog)
+#add_file_target(FILE sha1.v SCANNER_TYPE verilog)
 add_file_target(FILE sha256_fullfit.v SCANNER_TYPE verilog)
 add_file_target(FILE chandalar.pcf)
 
 add_fpga_target(
   NAME sha256_fullfit-ql-chandalar
   BOARD chandalar
-  SOURCES sha256_fullfit.v sha1.v
+  SOURCES sha256_fullfit.v #sha1.v
   INPUT_IO_FILE chandalar.pcf
   EXPLICIT_ADD_FILE_TARGET
   )


### PR DESCRIPTION
This pull requests fixes some issues with the designs:

- `cavlc_top`
  Some IOs were not constrained which caused Symbiflow not to use free SDIOMUX pads
- `iir`
  Similar situation as with cavlc_top
- `sha256_fullfit`
  This design contains two files `sha1.v` and `sha256_fullfit.v`. Both files define a single top-level module and do not reference each other. This caused Yosys to choose `sha1.v` as the top which presumably is not the one that should be used (It has 64 IO ports). I removed that file from the design.

With this pull request the `iir` design should successfully pass. The other two still won't fit in the device.
