### PR TITLE
Remove not existing files from toolchain wrappers

### DIFF
--- a/quicklogic/common/toolchain_wrappers/generate_constraints
+++ b/quicklogic/common/toolchain_wrappers/generate_constraints
@@ -22,7 +22,6 @@ fi
 echo "PINMAP FILE : $PINMAPCSV"
 echo "CLKMAP FILE : $CLKMAPCSV"
 
-CHANNELS=`realpath ${MYPATH}/../share/arch/${DEVICE}/channels.db`
 PINMAP=`realpath ${MYPATH}/../share/arch/${DEVICE}/${PINMAPCSV}`
 CLKMAP=`realpath ${MYPATH}/../share/arch/${DEVICE}/${CLKMAPCSV}`
 IOGEN=`realpath ${MYPATH}/python/create_ioplace.py`

--- a/quicklogic/common/toolchain_wrappers/write_bitstream
+++ b/quicklogic/common/toolchain_wrappers/write_bitstream
@@ -7,8 +7,6 @@ MYPATH=`dirname ${MYPATH}`
 source ${MYPATH}/env
 echo "Writing bitstream ..."
 
-FRAMES2BIT=`realpath ${VPRPATH}/xc7frames2bit`
-
 OPTS=d:f:b:P:
 LONGOPTS=device:,fasm:,bit:,part:
 


### PR DESCRIPTION
This PR removes references in toolchain wrappers to no longer existing files.

This can cause problems, as some implementations of ``realpath`` returns error code when file do not exists (e.g. on ``ubuntu 14`` or ``centos 6``)

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>