### PR TITLE
CLOCK constraint propagation

### DIFF
--- a/quicklogic/pp3/primitives/clock/clock_cell.sim.v
+++ b/quicklogic/pp3/primitives/clock/clock_cell.sim.v
@@ -4,6 +4,7 @@
 module CLOCK_CELL(I_PAD, O_CLK);
 
     (* iopad_external_pin *)
+    (* CLOCK, NO_COMB=0 *)
     input  wire I_PAD;
 
     (* CLOCK=0 *)

--- a/quicklogic/pp3/tests/gclk_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/gclk_counter/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_file_target(FILE gclk_counter.v SCANNER_TYPE verilog)
+add_file_target(FILE gclk_counter.sdc)
 add_file_target(FILE chandalar.pcf)
 
 add_fpga_target(
   NAME gclk_counter-ql-chandalar
   BOARD chandalar
   SOURCES gclk_counter.v
+  SDC_FILE gclk_counter.sdc
   INPUT_IO_FILE chandalar.pcf
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/pp3/tests/gclk_counter/chandalar.pcf
+++ b/quicklogic/pp3/tests/gclk_counter/chandalar.pcf
@@ -1,5 +1,5 @@
-set_io clk(0)   G6 # GPIO24 CLK0 IO81 G6 S3B_AP_I2S_DOUT     J6.4
-set_io clk(1)   H6 # GPIO23 CLK1 IO77 H6 S3B_AP_I2S_WD_CLKIN J6.6
+set_io clk0     G6 # GPIO24 CLK0 IO81 G6 S3B_AP_I2S_DOUT     J6.4
+set_io clk1     H6 # GPIO23 CLK1 IO77 H6 S3B_AP_I2S_WD_CLKIN J6.6
 
 set_io led(0)   H7
 set_io led(1)   G7

--- a/quicklogic/pp3/tests/gclk_counter/gclk_counter.sdc
+++ b/quicklogic/pp3/tests/gclk_counter/gclk_counter.sdc
@@ -1,0 +1,2 @@
+create_clock -period 100.0 clk0
+create_clock -period 50.0 clk1

--- a/quicklogic/pp3/tests/gclk_counter/gclk_counter.v
+++ b/quicklogic/pp3/tests/gclk_counter/gclk_counter.v
@@ -1,17 +1,18 @@
 module top(
-    input  wire [1:0] clk,
+    input  wire       clk0,
+    input  wire       clk1,
     output wire [3:0] led
 );
 
     // Counters
     reg [23:0] cnt0;
     initial cnt0 <= 0;
-    always @(posedge clk[0])
+    always @(posedge clk0)
         cnt0 <= cnt0 + 1;
 
     reg [23:0] cnt1;
     initial cnt1 <= 0;
-    always @(posedge clk[1])
+    always @(posedge clk1)
         cnt1 <= cnt1 + 1;
 
     // Outputs


### PR DESCRIPTION
With this PR the `CLOCK` cell becomes a clock buffer for VPR. This allows clock constraints to be provided for the top-level input net rather for the one that goes out of a 'CLOCK' cell. The change will allow constraints generated automatically by migen/nMigen to be correctly used by VPR.

**For this to work VPR version has to be updated**. Particularly this commit needs to be included: https://github.com/verilog-to-routing/vtr-verilog-to-routing/commit/c85560fc03a71a2b0d7b6314cc115161b0e58d8b.