### PR TITLE
jimbob: fix pads when no alias is present

### DIFF
--- a/quicklogic/common/utils/eos_s3_iomux_config.py
+++ b/quicklogic/common/utils/eos_s3_iomux_config.py
@@ -214,6 +214,8 @@ def main():
                 alias = pin_map_entry['alias']
                 pad_alias_map[alias] = name
                 pad_map[name] = alias
+            else:
+                pad_map[name] = name
 
         # Read and parse PCF
         with open(args.pcf, "r") as fp:

--- a/quicklogic/pp3/tests/btn_counter/jimbob4.pcf
+++ b/quicklogic/pp3/tests/btn_counter/jimbob4.pcf
@@ -1,4 +1,4 @@
-set_io clk      A1
+set_io clk      A3
 set_io led(0)   A2
 set_io led(1)   A3
 set_io led(2)   B1


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This fixes https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/issues/21.
The problem is that the WD30 package specification does not include aliases for the pin names.

To be consistent with the other packages, the PP3 packages should include the aliases as well.