### PR TITLE
rr_graph: remove penalty cost from switches

### DIFF
--- a/quicklogic/common/utils/routing_import.py
+++ b/quicklogic/common/utils/routing_import.py
@@ -667,9 +667,9 @@ def add_track_chain(graph, direction, u, v0, v1, segment_id, switch_id):
 
 def add_tracks_for_const_network(graph, const, tile_grid):
     """
-    Builds a network of CHANX/CHANY and edges to propagate signal from a 
+    Builds a network of CHANX/CHANY and edges to propagate signal from a
     const source.
-    
+
     The const network is purely artificial and does not correspond to any
     physical routing resources.
 
@@ -1025,7 +1025,7 @@ def populate_const_connections(graph, switchbox_models, tile_types, tile_grid,
         tile_type = tile_types[tile.type]
         if tile_type.fake_const_pin:
             tile_node = tile_pin_to_node[loc]["FAKE_CONST"]
-            
+
             for const in ["GND", "VCC"]:
                 const_node = const_node_map[const][loc]
                 connect(
@@ -1333,7 +1333,6 @@ def main():
                         c_out=switch.c_out,
                         c_internal=switch.c_int,
                         t_del=switch.t_del,
-                        p_cost=0.0
                     ),
                     sizing=rr.SwitchSizing(
                         mux_trans_size=0,

--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -68,7 +68,7 @@ class Channels(namedtuple(
 
 
 class SwitchTiming(namedtuple('SwitchTiming',
-                              'r c_in c_out c_internal t_del p_cost')):
+                              'r c_in c_out c_internal t_del')):
     """Encapsulation for timing attributes of a VPR switch
     see: https://vtr-verilog-to-routing.readthedocs.io/en/latest/arch/reference.html#switches
     """

--- a/utils/lib/rr_graph/tests/test_graph2.py
+++ b/utils/lib/rr_graph/tests/test_graph2.py
@@ -12,7 +12,7 @@ from ..tracks import Track, Direction
 class Graph2Tests(unittest.TestCase):
     def setUp(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         delayless = Switch(
@@ -27,7 +27,7 @@ class Graph2Tests(unittest.TestCase):
 
     def test_init(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         self.switches = [
@@ -244,7 +244,7 @@ class Graph2Tests(unittest.TestCase):
 class Graph2MediumTests(unittest.TestCase):
     def setUp(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         self.switches = [

--- a/utils/lib/rr_graph_capnp/graph2.py
+++ b/utils/lib/rr_graph_capnp/graph2.py
@@ -107,7 +107,6 @@ def read_switch(sw):
             c_out=timing.cout,
             c_internal=timing.cinternal,
             t_del=timing.tdel,
-            p_cost=timing.penaltyCost,
         ),
         sizing=graph2.SwitchSizing(
             buf_size=sizing.bufSize,
@@ -488,7 +487,6 @@ class Graph(object):
                 timing.cout = switch.timing.c_out
                 timing.r = switch.timing.r
                 timing.tdel = switch.timing.t_del
-                timing.penaltyCost = switch.timing.p_cost
 
             if switch.sizing:
                 sizing = out_switch.sizing

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -98,7 +98,6 @@ def graph_from_xml(
                 c_out=float(element.attrib.get('Cout', 0)),
                 c_internal=float(element.attrib.get('Cinternal', 0)),
                 t_del=float(element.attrib.get('Tdel', 0)),
-                p_cost=float(element.attrib.get('penalty_cost', 0)),
             )
 
         # Switch sizing
@@ -546,7 +545,6 @@ class Graph(object):
                     "Cin": switch.timing.c_in,
                     "Cout": switch.timing.c_out,
                     "Tdel": switch.timing.t_del,
-                    "penalty_cost": switch.timing.p_cost,
                 }
 
                 if VPR_HAS_C_INTERNAL_SUPPORT:


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR fixes an issue related to the penalty costs of switches that are not present in upstream VTR.