### PR TITLE
CI: add GH actions

### DIFF
--- a/.github/travis/common.sh
+++ b/.github/travis/common.sh
@@ -101,5 +101,5 @@ function end_section() {
 }
 
 export PATH=$PWD/env/conda/bin:$PATH
-export CC=gcc-6
-export CXX=g++-6
+export CC=gcc-8
+export CXX=g++-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+  pull_request:
+    branches: [ quicklogic-upstream-rebase ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Build
+        run: |
+          sudo apt update
+          sudo apt install -y g++-8 gcc-8 colordiff coreutils graphviz inkscape make git unzip cmake
+          source ./.github/travis/common.sh
+          stdbuf -i0 -o0 -e0 ./.github/travis/install.sh
+          mkdir .tmp
+          curl -L https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-linux.zip -o .tmp/ninja-linux.zip
+          unzip .tmp/ninja-linux.zip -d .tmp
+          export PATH=$PATH:$PWD/.tmp
+          stdbuf -i0 -o0 -e0 ./.github/travis/script.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-     - g++-6
+     - g++-8
      - bash
      - colordiff
      - coreutils


### PR DESCRIPTION
This PR adds initial GH actions CI flow. For now it copies the script used in travis. Later we can extend it to produce and upload architecture installation packages.

GH actions have 6h timeout so we should be able to perform packages generation and upload using this approach.