### PR TITLE
ql: cmake remove dependency on FASM in jlink and openocd

### DIFF
--- a/.github/travis/script.sh
+++ b/.github/travis/script.sh
@@ -27,8 +27,12 @@ end_section "info.conda.config"
 $SPACER
 
 echo "----------------------------------------"
+echo "Building all QuickLogicTests"
 (
-    make_target all_ql_tests "Building all quick targets"
+    # Build all tests
+    make_target all_ql_tests
+    # Build jlink and openocd targets
+    make_target all_ql_tests_prog
 )
 echo "----------------------------------------"
 

--- a/quicklogic/common/cmake/quicklogic_jlink.cmake
+++ b/quicklogic/common/cmake/quicklogic_jlink.cmake
@@ -20,8 +20,6 @@ function(ADD_JLINK_OUTPUT)
   get_target_property_required(PYTHON3 env PYTHON3)
   get_target_property_required(PYTHON3_TARGET env PYTHON3_TARGET)
 
-  get_target_property_required(QLFASM_TARGET env QLFASM_TARGET)
-
   get_target_property_required(EBLIF ${PARENT} EBLIF)
   get_target_property_required(PCF ${PARENT} INPUT_IO_FILE)
   get_target_property_required(BITSTREAM ${PARENT} BIT)
@@ -34,7 +32,7 @@ function(ADD_JLINK_OUTPUT)
   get_file_location(EBLIF_LOC ${EBLIF})
   get_file_location(PCF_LOC ${PCF})
   get_target_property_required(BOARD ${PARENT} BOARD)
-  
+
   set(PINMAP ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/pp3/${BOARD}_pinmap.csv)
 
   # Generate a JLINK script that sets IOMUX configuration.
@@ -62,7 +60,7 @@ function(ADD_JLINK_OUTPUT)
   add_custom_command(
     OUTPUT ${WORK_DIR}/${BIT_AS_JLINK}
     COMMAND ${PYTHON3} ${BIT_TO_JLINK} ${BITSTREAM_LOC} ${WORK_DIR}/${BIT_AS_JLINK}
-    DEPENDS ${PYTHON3_TARGET} ${QLFASM_TARGET} ${BIT_TO_JLINK} ${BITSTREAM}
+    DEPENDS ${PYTHON3_TARGET} ${BIT_TO_JLINK} ${BITSTREAM}
   )
 
   add_file_target(FILE ${WORK_DIR_REL}/${BIT_AS_JLINK} GENERATED)

--- a/quicklogic/common/cmake/quicklogic_openocd.cmake
+++ b/quicklogic/common/cmake/quicklogic_openocd.cmake
@@ -20,8 +20,6 @@ function(ADD_OPENOCD_OUTPUT)
   get_target_property_required(PYTHON3 env PYTHON3)
   get_target_property_required(PYTHON3_TARGET env PYTHON3_TARGET)
 
-  get_target_property_required(QLFASM_TARGET env QLFASM_TARGET)
-
   get_target_property_required(EBLIF ${PARENT} EBLIF)
   get_target_property_required(PCF ${PARENT} INPUT_IO_FILE)
   get_target_property_required(BITSTREAM ${PARENT} BIT)
@@ -34,7 +32,7 @@ function(ADD_OPENOCD_OUTPUT)
   get_file_location(EBLIF_LOC ${EBLIF})
   get_file_location(PCF_LOC ${PCF})
   get_target_property_required(BOARD ${PARENT} BOARD)
-  
+
   set(PINMAP ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/pp3/${BOARD}_pinmap.csv)
 
   # Generate a OpenOCD script that sets IOMUX configuration.
@@ -62,7 +60,7 @@ function(ADD_OPENOCD_OUTPUT)
   add_custom_command(
     OUTPUT ${WORK_DIR}/${BIT_AS_OPENOCD}
     COMMAND ${PYTHON3} ${BIT_TO_OPENOCD} ${BITSTREAM_LOC} ${WORK_DIR}/${BIT_AS_OPENOCD}
-    DEPENDS ${PYTHON3_TARGET} ${QLFASM_TARGET} ${BIT_TO_OPENOCD} ${BITSTREAM}
+    DEPENDS ${PYTHON3_TARGET} ${BIT_TO_OPENOCD} ${BITSTREAM}
   )
 
   add_file_target(FILE ${WORK_DIR_REL}/${BIT_AS_OPENOCD} GENERATED)

--- a/quicklogic/pp3/tests/CMakeLists.txt
+++ b/quicklogic/pp3/tests/CMakeLists.txt
@@ -1,4 +1,11 @@
+add_custom_target(all_ql_tests_bit)
+add_custom_target(all_ql_tests_prog)
+
+add_dependencies(all_ql_tests_prog all_ql_tests_bit)
+
 add_custom_target(all_ql_tests)
+add_dependencies(all_ql_tests all_ql_tests_bit)
+
 add_custom_target(all_quick_tests)
 
 # A test for LUT -> LOGIC cell techmaps

--- a/quicklogic/pp3/tests/bram/CMakeLists.txt
+++ b/quicklogic/pp3/tests/bram/CMakeLists.txt
@@ -17,7 +17,7 @@ add_openocd_output(
   PARENT bram-ql-chandalar
 )
 
-add_dependencies(all_ql_tests bram-ql-chandalar_bit)
-add_dependencies(all_ql_tests bram-ql-chandalar_jlink)
-add_dependencies(all_ql_tests bram-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit bram-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog bram-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog bram-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
@@ -23,9 +23,9 @@ add_dependencies(all_quick_tests btn_counter-ql-chandalar_bit)
 add_dependencies(all_quick_tests btn_counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests btn_counter-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests btn_counter-ql-chandalar_bit)
-add_dependencies(all_ql_tests btn_counter-ql-chandalar_jlink)
-add_dependencies(all_ql_tests btn_counter-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit btn_counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_openocd)
 
 
 add_fpga_target(
@@ -44,9 +44,9 @@ add_openocd_output(
   PARENT btn_counter-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests btn_counter-ql-quickfeather_bit)
-add_dependencies(all_ql_tests btn_counter-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests btn_counter-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_bit btn_counter-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_jlink)
+add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_openocd)
 
 # add_fpga_target(
 #  NAME btn_counter-ql-jimbob4

--- a/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
@@ -21,7 +21,7 @@ add_dependencies(all_quick_tests btn_ff-ql-chandalar_bit)
 add_dependencies(all_quick_tests btn_ff-ql-chandalar_jlink)
 add_dependencies(all_quick_tests btn_ff-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests btn_ff-ql-chandalar_bit)
-add_dependencies(all_ql_tests btn_ff-ql-chandalar_jlink)
-add_dependencies(all_ql_tests btn_ff-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit btn_ff-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
@@ -21,7 +21,7 @@ add_dependencies(all_quick_tests btn_xor-ql-chandalar_bit)
 add_dependencies(all_quick_tests btn_xor-ql-chandalar_jlink)
 add_dependencies(all_quick_tests btn_xor-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests btn_xor-ql-chandalar_bit)
-add_dependencies(all_ql_tests btn_xor-ql-chandalar_jlink)
-add_dependencies(all_ql_tests btn_xor-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit btn_xor-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/counter/CMakeLists.txt
@@ -22,9 +22,9 @@ add_dependencies(all_quick_tests counter-ql-chandalar_bit)
 add_dependencies(all_quick_tests counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests counter-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests counter-ql-chandalar_bit)
-add_dependencies(all_ql_tests counter-ql-chandalar_jlink)
-add_dependencies(all_ql_tests counter-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog counter-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog counter-ql-chandalar_openocd)
 
 
 add_fpga_target(
@@ -43,7 +43,7 @@ add_openocd_output(
   PARENT counter-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests counter-ql-quickfeather_bit)
-add_dependencies(all_ql_tests counter-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests counter-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_bit counter-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_prog counter-ql-quickfeather_jlink)
+add_dependencies(all_ql_tests_prog counter-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
@@ -21,9 +21,9 @@ add_dependencies(all_quick_tests ext_counter-ql-chandalar_bit)
 add_dependencies(all_quick_tests ext_counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests ext_counter-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests ext_counter-ql-chandalar_bit)
-add_dependencies(all_ql_tests ext_counter-ql-chandalar_jlink)
-add_dependencies(all_ql_tests ext_counter-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit ext_counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_openocd)
 
 
 add_file_target(FILE quickfeather.pcf)
@@ -44,7 +44,7 @@ add_openocd_output(
   PARENT ext_counter-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests ext_counter-ql-quickfeather_bit)
-add_dependencies(all_ql_tests ext_counter-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests ext_counter-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_bit ext_counter-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_jlink)
+add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/gclk_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/gclk_counter/CMakeLists.txt
@@ -19,8 +19,8 @@ add_openocd_output(
   PARENT gclk_counter-ql-chandalar
 )
 
-add_dependencies(all_ql_tests gclk_counter-ql-chandalar_bit)
-add_dependencies(all_ql_tests gclk_counter-ql-chandalar_jlink)
-add_dependencies(all_ql_tests gclk_counter-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit gclk_counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog gclk_counter-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog gclk_counter-ql-chandalar_openocd)
 add_dependencies(all_quick_tests gclk_counter-ql-chandalar_analysis)
 add_dependencies(gclk_counter-ql-chandalar_analysis gclk_counter-ql-chandalar_bit_v)

--- a/quicklogic/pp3/tests/mult/CMakeLists.txt
+++ b/quicklogic/pp3/tests/mult/CMakeLists.txt
@@ -21,7 +21,7 @@ add_dependencies(all_quick_tests mult-ql-chandalar_bit)
 add_dependencies(all_quick_tests mult-ql-chandalar_jlink)
 add_dependencies(all_quick_tests mult-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests mult-ql-chandalar_bit)
-add_dependencies(all_ql_tests mult-ql-chandalar_jlink)
-add_dependencies(all_ql_tests mult-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit mult-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog mult-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog mult-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/Simon_bit_serial_top_module/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/Simon_bit_serial_top_module/CMakeLists.txt
@@ -21,8 +21,8 @@ add_openocd_output(
   PARENT simon-bit-serial-ql-chandalar
 )
 
-add_dependencies(all_ql_tests simon-bit-serial-ql-chandalar_bit)
-add_dependencies(all_ql_tests simon-bit-serial-ql-chandalar_jlink)
-add_dependencies(all_ql_tests simon-bit-serial-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  simon-bit-serial-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog simon-bit-serial-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog simon-bit-serial-ql-chandalar_openocd)
 add_dependencies(all_quick_tests simon-bit-serial-ql-chandalar_analysis)
 add_dependencies(all_quick_tests testbench_Simon_bit_serial_tb)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/bin2seven/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/bin2seven/CMakeLists.txt
@@ -17,6 +17,6 @@ add_openocd_output(
   PARENT bin2seven-ql-chandalar
 )
 
-add_dependencies(all_ql_tests bin2seven-ql-chandalar_bit)
-add_dependencies(all_ql_tests bin2seven-ql-chandalar_jlink)
-add_dependencies(all_ql_tests bin2seven-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  bin2seven-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog bin2seven-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog bin2seven-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/camif/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/camif/CMakeLists.txt
@@ -18,8 +18,8 @@ add_openocd_output(
   PARENT camif-ql-chandalar
 )
 
-add_dependencies(all_ql_tests camif-ql-chandalar_bit)
-add_dependencies(all_ql_tests camif-ql-chandalar_jlink)
-add_dependencies(all_ql_tests camif-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  camif-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog camif-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog camif-ql-chandalar_openocd)
 add_dependencies(all_quick_tests camif-ql-chandalar_analysis)
 add_dependencies(camif-ql-chandalar_analysis camif-ql-chandalar_bit_v)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/clock_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/clock_test/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE chandalar.pcf)
 add_fpga_target(
   NAME clock_test-ql-chandalar
   BOARD chandalar
-  SOURCES AL4S3B_FPGA_Top.v 
+  SOURCES AL4S3B_FPGA_Top.v
   INPUT_IO_FILE chandalar.pcf
   EXPLICIT_ADD_FILE_TARGET
   )
@@ -17,8 +17,8 @@ add_openocd_output(
   PARENT clock_test-ql-chandalar
 )
 
-add_dependencies(all_ql_tests clock_test-ql-chandalar_bit)
-add_dependencies(all_ql_tests clock_test-ql-chandalar_jlink)
-add_dependencies(all_ql_tests clock_test-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  clock_test-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog clock_test-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog clock_test-ql-chandalar_openocd)
 add_dependencies(all_quick_tests clock_test-ql-chandalar_analysis)
 add_dependencies(clock_test-ql-chandalar_analysis clock_test-ql-chandalar_bit_v)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/clock_tree_design/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/clock_tree_design/CMakeLists.txt
@@ -17,6 +17,6 @@ add_openocd_output(
   PARENT clock-tree-design-ql-chandalar
 )
 
-add_dependencies(all_ql_tests clock-tree-design-ql-chandalar_bit)
-add_dependencies(all_ql_tests clock-tree-design-ql-chandalar_jlink)
-add_dependencies(all_ql_tests clock-tree-design-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  clock-tree-design-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog clock-tree-design-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog clock-tree-design-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/counter_16bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/counter_16bit/CMakeLists.txt
@@ -19,9 +19,9 @@ add_openocd_output(
   PARENT counter_16bit-ql-chandalar
 )
 
-add_dependencies(all_ql_tests counter_16bit-ql-chandalar_bit)
-add_dependencies(all_ql_tests counter_16bit-ql-chandalar_jlink)
-add_dependencies(all_ql_tests counter_16bit-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  counter_16bit-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog counter_16bit-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog counter_16bit-ql-chandalar_openocd)
 add_dependencies(all_quick_tests counter_16bit-ql-chandalar_analysis)
 add_dependencies(all_quick_tests testbench_counter_16bit_tb)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/counter_32bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/counter_32bit/CMakeLists.txt
@@ -17,7 +17,7 @@ add_openocd_output(
   PARENT counter_32bit-ql-chandalar
 )
 
-add_dependencies(all_ql_tests counter_32bit-ql-chandalar_bit)
-add_dependencies(all_ql_tests counter_32bit-ql-chandalar_jlink)
-add_dependencies(all_ql_tests counter_32bit-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  counter_32bit-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog counter_32bit-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog counter_32bit-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/counter_8bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/counter_8bit/CMakeLists.txt
@@ -17,7 +17,7 @@ add_openocd_output(
   PARENT counter_8bit-ql-chandalar
 )
 
-add_dependencies(all_ql_tests counter_8bit-ql-chandalar_bit)
-add_dependencies(all_ql_tests counter_8bit-ql-chandalar_jlink)
-add_dependencies(all_ql_tests counter_8bit-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  counter_8bit-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog counter_8bit-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog counter_8bit-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/counter_al4s3b/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/counter_al4s3b/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_file_target(FILE AL4S3B_FPGA_QL_Reserved.v SCANNER TYPE verilog)
 add_file_target(FILE AL4S3B_FPGA_Registers.v SCANNER TYPE verilog)
 add_file_target(FILE AL4S3B_FPGA_IP.v SCANNER TYPE verilog)
-add_file_target(FILE AL4S3B_FPGA_Top.v SCANNER TYPE verilog) 
+add_file_target(FILE AL4S3B_FPGA_Top.v SCANNER TYPE verilog)
 add_file_target(FILE chandalar.pcf)
 add_file_target(FILE jlink_cmds.txt)
 add_file_target(FILE jlink_out_gold)
@@ -10,7 +10,7 @@ add_file_target(FILE jlink_script.sh)
 add_fpga_target(
   NAME counter_al4s3b-ql-chandalar
   BOARD chandalar
-  SOURCES AL4S3B_FPGA_Top.v AL4S3B_FPGA_IP.v AL4S3B_FPGA_Registers.v AL4S3B_FPGA_QL_Reserved.v 
+  SOURCES AL4S3B_FPGA_Top.v AL4S3B_FPGA_IP.v AL4S3B_FPGA_Registers.v AL4S3B_FPGA_QL_Reserved.v
   INPUT_IO_FILE chandalar.pcf
   EXPLICIT_ADD_FILE_TARGET
   )
@@ -23,6 +23,6 @@ add_openocd_output(
   PARENT counter_al4s3b-ql-chandalar
 )
 
-add_dependencies(all_ql_tests counter_al4s3b-ql-chandalar_bit)
-add_dependencies(all_ql_tests counter_al4s3b-ql-chandalar_jlink)
-add_dependencies(all_ql_tests counter_al4s3b-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  counter_al4s3b-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog counter_al4s3b-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog counter_al4s3b-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design1/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design1/CMakeLists.txt
@@ -33,7 +33,7 @@ add_openocd_output(
   PARENT design1-ql-chandalar
 )
 
-add_dependencies(all_ql_tests design1-ql-chandalar_bit)
-add_dependencies(all_ql_tests design1-ql-chandalar_jlink)
-add_dependencies(all_ql_tests design1-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  design1-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog design1-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog design1-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design10/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design10/CMakeLists.txt
@@ -24,7 +24,7 @@ add_openocd_output(
   PARENT design10-ql-chandalar
 )
 
-add_dependencies(all_ql_tests design10-ql-chandalar_bit)
-add_dependencies(all_ql_tests design10-ql-chandalar_jlink)
-add_dependencies(all_ql_tests design10-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  design10-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog design10-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog design10-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design2/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design2/CMakeLists.txt
@@ -35,7 +35,7 @@ add_openocd_output(
   PARENT design2-ql-chandalar
 )
 
-add_dependencies(all_ql_tests design2-ql-chandalar_bit)
-add_dependencies(all_ql_tests design2-ql-chandalar_jlink)
-add_dependencies(all_ql_tests design2-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  design2-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog design2-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog design2-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design3/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design3/CMakeLists.txt
@@ -17,7 +17,7 @@ add_file_target(FILE chandalar.pcf)
 add_fpga_target(
   NAME design3-ql-chandalar
   BOARD chandalar
-  SOURCES AL4S3B_FPGA_Top.v AL4S3B_FPGA_IP.v AL4S3B_FPGA_Registers.v i2s_slave_w_DMA.v i2s_slave_rx.v i2s_slave_w_DMA_registers.v i2s_slave_w_DMA_StateMachine.v i2s_slave_Rx_FIFOs.v deci_filter_fir128coeff.v fll_acslip.v r512x16_512x16.v af512x16_512x16.v fifo_blk.v ram_blk.v 
+  SOURCES AL4S3B_FPGA_Top.v AL4S3B_FPGA_IP.v AL4S3B_FPGA_Registers.v i2s_slave_w_DMA.v i2s_slave_rx.v i2s_slave_w_DMA_registers.v i2s_slave_w_DMA_StateMachine.v i2s_slave_Rx_FIFOs.v deci_filter_fir128coeff.v fll_acslip.v r512x16_512x16.v af512x16_512x16.v fifo_blk.v ram_blk.v
   INPUT_IO_FILE chandalar.pcf
   EXPLICIT_ADD_FILE_TARGET
   )
@@ -30,6 +30,6 @@ add_openocd_output(
   PARENT design3-ql-chandalar
 )
 
-add_dependencies(all_ql_tests design3-ql-chandalar_bit)
-add_dependencies(all_ql_tests design3-ql-chandalar_jlink)
-add_dependencies(all_ql_tests design3-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  design3-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog design3-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog design3-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design6/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design6/CMakeLists.txt
@@ -23,7 +23,7 @@ add_openocd_output(
   PARENT design6-ql-chandalar
 )
 
-add_dependencies(all_ql_tests design6-ql-chandalar_bit)
-add_dependencies(all_ql_tests design6-ql-chandalar_jlink)
-add_dependencies(all_ql_tests design6-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  design6-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog design6-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog design6-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design8/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design8/CMakeLists.txt
@@ -34,7 +34,7 @@ add_openocd_output(
   PARENT design8-ql-chandalar
 )
 
-add_dependencies(all_ql_tests design8-ql-chandalar_bit)
-add_dependencies(all_ql_tests design8-ql-chandalar_jlink)
-add_dependencies(all_ql_tests design8-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  design8-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog design8-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog design8-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design9/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design9/CMakeLists.txt
@@ -12,7 +12,7 @@ add_file_target(FILE chandalar.pcf)
 add_fpga_target(
   NAME design9-ql-chandalar
   BOARD chandalar
-  SOURCES AL4S3B_FPGA_Top.v AL4S3B_FPGA_IP.v AL4S3B_FPGA_Registers.v AL4S3B_FPGA_QL_Reserved.v I2C_Master_w_CmdQueue.v i2c_master_top.v i2c_master_byte_ctrl.v i2c_master_bit_ctrl.v i2c_master_defines.v  
+  SOURCES AL4S3B_FPGA_Top.v AL4S3B_FPGA_IP.v AL4S3B_FPGA_Registers.v AL4S3B_FPGA_QL_Reserved.v I2C_Master_w_CmdQueue.v i2c_master_top.v i2c_master_byte_ctrl.v i2c_master_bit_ctrl.v i2c_master_defines.v
   INPUT_IO_FILE chandalar.pcf
   EXPLICIT_ADD_FILE_TARGET
   )
@@ -25,7 +25,7 @@ add_openocd_output(
   PARENT design9-ql-chandalar
 )
 
-add_dependencies(all_ql_tests design9-ql-chandalar_bit)
-add_dependencies(all_ql_tests design9-ql-chandalar_jlink)
-add_dependencies(all_ql_tests design9-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  design9-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog design9-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog design9-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/fifo_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/fifo_test/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE af512x32_512x32.v SCANNER TYPE verilog)
 add_file_target(FILE AL4S3B_FPGA_QL_Reserved.v SCANNER TYPE verilog)
 add_file_target(FILE AL4S3B_FPGA_Registers.v SCANNER TYPE verilog)
 add_file_target(FILE AL4S3B_FPGA_IP.v SCANNER TYPE verilog)
-add_file_target(FILE AL4S3B_FPGA_Top.v SCANNER TYPE verilog) 
+add_file_target(FILE AL4S3B_FPGA_Top.v SCANNER TYPE verilog)
 add_file_target(FILE chandalar.pcf)
 
 add_fpga_target(
@@ -23,7 +23,7 @@ add_openocd_output(
   PARENT fifo_test-ql-chandalar
 )
 
-#add_dependencies(all_ql_tests fifo_test-ql-chandalar_bit)
-add_dependencies(all_ql_tests fifo_test-ql-chandalar_jlink)
-add_dependencies(all_ql_tests fifo_test-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  fifo_test-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog fifo_test-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog fifo_test-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/i2c_master_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/i2c_master_top/CMakeLists.txt
@@ -21,9 +21,9 @@ add_openocd_output(
   PARENT i2c_master_top-ql-chandalar
 )
 
-add_dependencies(all_ql_tests i2c_master_top-ql-chandalar_bit)
-add_dependencies(all_ql_tests i2c_master_top-ql-chandalar_jlink)
-add_dependencies(all_ql_tests i2c_master_top-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  i2c_master_top-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog i2c_master_top-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog i2c_master_top-ql-chandalar_openocd)
 add_dependencies(all_quick_tests i2c_master_top-ql-chandalar_analysis)
 add_dependencies(i2c_master_top-ql-chandalar_analysis i2c_master_top-ql-chandalar_bit_v)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/jpeg_qnr/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/jpeg_qnr/CMakeLists.txt
@@ -20,7 +20,7 @@ add_openocd_output(
   PARENT jpeg-ql-chandalar
 )
 
-add_dependencies(all_ql_tests jpeg-ql-chandalar_bit)
-add_dependencies(all_ql_tests jpeg-ql-chandalar_jlink)
-add_dependencies(all_ql_tests jpeg-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit jpeg-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog jpeg-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog jpeg-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/mult_8bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/mult_8bit/CMakeLists.txt
@@ -19,9 +19,9 @@ add_openocd_output(
   PARENT mult_8bit-ql-chandalar
 )
 
-add_dependencies(all_ql_tests mult_8bit-ql-chandalar_bit)
-add_dependencies(all_ql_tests mult_8bit-ql-chandalar_jlink)
-add_dependencies(all_ql_tests mult_8bit-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  mult_8bit-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog mult_8bit-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog mult_8bit-ql-chandalar_openocd)
 add_dependencies(all_quick_tests mult_8bit-ql-chandalar_analysis)
 add_dependencies(mult_8bit-ql-chandalar_analysis mult_8bit-ql-chandalar_bit_v)
 add_dependencies(all_quick_tests testbench_mult_8bit_tb)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/osc_alu/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/osc_alu/CMakeLists.txt
@@ -21,9 +21,9 @@ add_openocd_output(
   PARENT osc_alu-ql-chandalar
 )
 
-add_dependencies(all_ql_tests osc_alu-ql-chandalar_bit)
-add_dependencies(all_ql_tests osc_alu-ql-chandalar_jlink)
-add_dependencies(all_ql_tests osc_alu-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  osc_alu-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog osc_alu-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog osc_alu-ql-chandalar_openocd)
 add_dependencies(all_quick_tests osc_alu-ql-chandalar_analysis)
 add_dependencies(osc_alu-ql-chandalar_analysis osc_alu-ql-chandalar_bit_v)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/ram_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/ram_test/CMakeLists.txt
@@ -7,7 +7,7 @@ add_file_target(FILE AL4S3B_FPGA_QL_Reserved.v SCANNER TYPE verilog)
 add_file_target(FILE AL4S3B_FPGA_RAMs.v SCANNER TYPE verilog)
 add_file_target(FILE AL4S3B_FPGA_Registers.v SCANNER TYPE verilog)
 add_file_target(FILE AL4S3B_FPGA_IP.v SCANNER TYPE verilog)
-add_file_target(FILE AL4S3B_FPGA_Top.v SCANNER TYPE verilog) 
+add_file_target(FILE AL4S3B_FPGA_Top.v SCANNER TYPE verilog)
 add_file_target(FILE chandalar.pcf)
 add_file_target(FILE init_1024x16.hex)
 add_file_target(FILE init_1024x8.hex)
@@ -26,8 +26,8 @@ add_custom_command(OUTPUT r512x16_512x16.v DEPENDS init_512x16.hex APPEND)
 add_fpga_target(
   NAME ram_test-ql-chandalar
   BOARD chandalar
-  SOURCES AL4S3B_FPGA_Top.v AL4S3B_FPGA_IP.v AL4S3B_FPGA_Registers.v AL4S3B_FPGA_RAMs.v AL4S3B_FPGA_QL_Reserved.v  r512x16_512x16.v r1024x16_1024x16.v r1024x8_1024x8.v r512x32_512x32.v r2048x8_2048x8.v 
-  INPUT_IO_FILE chandalar.pcf 
+  SOURCES AL4S3B_FPGA_Top.v AL4S3B_FPGA_IP.v AL4S3B_FPGA_Registers.v AL4S3B_FPGA_RAMs.v AL4S3B_FPGA_QL_Reserved.v  r512x16_512x16.v r1024x16_1024x16.v r1024x8_1024x8.v r512x32_512x32.v r2048x8_2048x8.v
+  INPUT_IO_FILE chandalar.pcf
   EXPLICIT_ADD_FILE_TARGET
   )
 
@@ -39,7 +39,7 @@ add_openocd_output(
   PARENT ram_test-ql-chandalar
 )
 
-#add_dependencies(all_ql_tests ram_test-ql-chandalar_bit)
-add_dependencies(all_ql_tests ram_test-ql-chandalar_jlink)
-add_dependencies(all_ql_tests ram_test-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  ram_test-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog ram_test-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog ram_test-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/rgb2ycrcb/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/rgb2ycrcb/CMakeLists.txt
@@ -17,9 +17,9 @@ add_openocd_output(
   PARENT rgb2ycrcb-ql-chandalar
 )
 
-add_dependencies(all_ql_tests rgb2ycrcb-ql-chandalar_bit)
-add_dependencies(all_ql_tests rgb2ycrcb-ql-chandalar_jlink)
-add_dependencies(all_ql_tests rgb2ycrcb-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  rgb2ycrcb-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog rgb2ycrcb-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog rgb2ycrcb-ql-chandalar_openocd)
 
 add_file_target(FILE quickfeather.pcf)
 
@@ -39,7 +39,7 @@ add_openocd_output(
   PARENT rgb2ycrcb-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests rgb2ycrcb-ql-quickfeather_bit)
-add_dependencies(all_ql_tests rgb2ycrcb-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests rgb2ycrcb-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_bit  rgb2ycrcb-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_prog rgb2ycrcb-ql-quickfeather_jlink)
+add_dependencies(all_ql_tests_prog rgb2ycrcb-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/rs_decoder_1/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/rs_decoder_1/CMakeLists.txt
@@ -17,7 +17,7 @@ add_openocd_output(
   PARENT rs-decoder-ql-chandalar
 )
 
-add_dependencies(all_ql_tests rs-decoder-ql-chandalar_bit)
-add_dependencies(all_ql_tests rs-decoder-ql-chandalar_jlink)
-add_dependencies(all_ql_tests rs-decoder-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  rs-decoder-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog rs-decoder-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog rs-decoder-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/spi_master_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/spi_master_top/CMakeLists.txt
@@ -22,6 +22,6 @@ add_openocd_output(
   PARENT spi_master_top-ql-chandalar
 )
 
-add_dependencies(all_ql_tests spi_master_top-ql-chandalar_bit)
-add_dependencies(all_ql_tests spi_master_top-ql-chandalar_jlink)
-add_dependencies(all_ql_tests spi_master_top-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  spi_master_top-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog spi_master_top-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog spi_master_top-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/test_logic_cell/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/test_logic_cell/CMakeLists.txt
@@ -17,6 +17,6 @@ add_openocd_output(
   PARENT test_logic_cell-ql-chandalar
 )
 
-add_dependencies(all_ql_tests test_logic_cell-ql-chandalar_bit)
-add_dependencies(all_ql_tests test_logic_cell-ql-chandalar_jlink)
-add_dependencies(all_ql_tests test_logic_cell-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  test_logic_cell-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog test_logic_cell-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog test_logic_cell-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/top_120_13/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/top_120_13/CMakeLists.txt
@@ -17,7 +17,7 @@ add_openocd_output(
   PARENT top-120-13-ql-chandalar
 )
 
-add_dependencies(all_ql_tests top-120-13-ql-chandalar_bit)
-add_dependencies(all_ql_tests top-120-13-ql-chandalar_jlink)
-add_dependencies(all_ql_tests top-120-13-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  top-120-13-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog top-120-13-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog top-120-13-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/wbqspiflash/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/wbqspiflash/CMakeLists.txt
@@ -21,9 +21,9 @@ add_openocd_output(
   PARENT wbqspiflash-ql-chandalar
 )
 
-add_dependencies(all_ql_tests wbqspiflash-ql-chandalar_bit)
-add_dependencies(all_ql_tests wbqspiflash-ql-chandalar_jlink)
-add_dependencies(all_ql_tests wbqspiflash-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  wbqspiflash-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog wbqspiflash-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog wbqspiflash-ql-chandalar_openocd)
 
 add_file_target(FILE quickfeather.pcf)
 
@@ -43,7 +43,7 @@ add_openocd_output(
   PARENT wbqspiflash-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests wbqspiflash-ql-quickfeather_bit)
-add_dependencies(all_ql_tests wbqspiflash-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests wbqspiflash-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_bit  wbqspiflash-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_prog wbqspiflash-ql-quickfeather_jlink)
+add_dependencies(all_ql_tests_prog wbqspiflash-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/ram/CMakeLists.txt
+++ b/quicklogic/pp3/tests/ram/CMakeLists.txt
@@ -21,7 +21,7 @@ add_dependencies(all_quick_tests ram-ql-chandalar_bit)
 add_dependencies(all_quick_tests ram-ql-chandalar_jlink)
 add_dependencies(all_quick_tests ram-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests ram-ql-chandalar_bit)
-add_dependencies(all_ql_tests ram-ql-chandalar_jlink)
-add_dependencies(all_ql_tests ram-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit ram-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog ram-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog ram-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/sdiomux_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/sdiomux_counter/CMakeLists.txt
@@ -21,7 +21,7 @@ add_dependencies(all_quick_tests sdiomux-counter-ql-chandalar_bit)
 add_dependencies(all_quick_tests sdiomux-counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests sdiomux-counter-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests sdiomux-counter-ql-chandalar_bit)
-add_dependencies(all_ql_tests sdiomux-counter-ql-chandalar_jlink)
-add_dependencies(all_ql_tests sdiomux-counter-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit sdiomux-counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog sdiomux-counter-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog sdiomux-counter-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
@@ -21,7 +21,7 @@ add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_bit)
 add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_jlink)
 add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests sdiomux_xor-ql-chandalar_bit)
-add_dependencies(all_ql_tests sdiomux_xor-ql-chandalar_jlink)
-add_dependencies(all_ql_tests sdiomux_xor-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit sdiomux_xor-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/soc_clocks/CMakeLists.txt
+++ b/quicklogic/pp3/tests/soc_clocks/CMakeLists.txt
@@ -21,9 +21,9 @@ add_dependencies(all_quick_tests soc_clocks-ql-chandalar_bit)
 add_dependencies(all_quick_tests soc_clocks-ql-chandalar_jlink)
 add_dependencies(all_quick_tests soc_clocks-ql-chandalar_openocd)
 
-add_dependencies(all_ql_tests soc_clocks-ql-chandalar_bit)
-add_dependencies(all_ql_tests soc_clocks-ql-chandalar_jlink)
-add_dependencies(all_ql_tests soc_clocks-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit soc_clocks-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog soc_clocks-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog soc_clocks-ql-chandalar_openocd)
 add_dependencies(all_quick_tests soc_clocks-ql-chandalar_analysis)
 add_dependencies(soc_clocks-ql-chandalar_analysis soc_clocks-ql-chandalar_bit_v)
 
@@ -46,6 +46,6 @@ add_openocd_output(
   PARENT soc_clocks-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests soc_clocks-ql-quickfeather_bit)
-add_dependencies(all_ql_tests soc_clocks-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests soc_clocks-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_bit  soc_clocks-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_prog soc_clocks-ql-quickfeather_jlink)
+add_dependencies(all_ql_tests_prog soc_clocks-ql-quickfeather_openocd)

--- a/quicklogic/pp3/tests/soc_litex_pwm/CMakeLists.txt
+++ b/quicklogic/pp3/tests/soc_litex_pwm/CMakeLists.txt
@@ -18,9 +18,9 @@ add_openocd_output(
   PARENT soc_litex_pwm-ql-chandalar
 )
 
-add_dependencies(all_ql_tests soc_litex_pwm-ql-chandalar_bit)
-add_dependencies(all_ql_tests soc_litex_pwm-ql-chandalar_jlink)
-add_dependencies(all_ql_tests soc_litex_pwm-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_bit  soc_litex_pwm-ql-chandalar_bit)
+add_dependencies(all_ql_tests_prog soc_litex_pwm-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog soc_litex_pwm-ql-chandalar_openocd)
 
 add_file_target(FILE quickfeather.pcf)
 
@@ -40,7 +40,7 @@ add_openocd_output(
   PARENT soc_litex_pwm-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests soc_litex_pwm-ql-quickfeather_bit)
-add_dependencies(all_ql_tests soc_litex_pwm-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests soc_litex_pwm-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_bit  soc_litex_pwm-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_prog soc_litex_pwm-ql-quickfeather_jlink)
+add_dependencies(all_ql_tests_prog soc_litex_pwm-ql-quickfeather_openocd)
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR solves https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/176.

The problem is related to some race conditions happening due to the fact that the jlink and openocd targets where depending on the fasm target. This resulted in the same fasm file being simultaneously updated by different targets, when running the multi-process build with make.