### PR TITLE
fpga-bootloading-changes-phase-1-PR-2

### DIFF
--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -381,9 +381,14 @@ DEVICE  := $DEVICE\n\
 PCF := $PCF_MAKE\n\
 SDC := $SDC_MAKE\n\
 BUILDDIR := build\n\n\
+HEX_FILES := \${current_dir}/*.hex
+
 all: \${BUILDDIR}/\${TOP}.bit\n\
 \n\
 \${BUILDDIR}/\${TOP}.eblif: \${VERILOG} \${PCF}\n\
+  ifneq (\"\$(wildcard \$(HEX_FILES))\",\"\")\n\
+	\$(shell cp \${current_dir}/*.hex \${BUILDDIR})\n\
+  endif\n\
 	cd \${BUILDDIR} && symbiflow_synth -t \${TOP} -v \${VERILOG} -d \${DEVICE} -p \${PCF} -P \${PART} 2>&1 > $LOG_FILE\n\
 \n\
 \${BUILDDIR}/\${TOP}.net: \${BUILDDIR}/\${TOP}.eblif\n\

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -21,8 +21,8 @@ echo -e "\nBelow are the supported commands: \n\
 \t>ql_symbiflow -synth -src <source_dir path> -d <device> -P <package> -t <top> -v <verilog file/files> -p <pcf file>  \n\
  To run synthesis, pack, place and route, generate bitstream:\n\
 \t>ql_symbiflow -compile -src <source_dir path> -d <device> -P <package> -t <top> -v <verilog file/files> -p <pcf file>  \n\
- To dump the jlink/post_verilog/header file: \n\
-\t>ql_symbiflow -compile -src <source_dir path> -d <device> -P <package> -t <top> -v <verilog file/files> -p <pcf file> -dump <jlink/post_verilog/header/openocd> \n\
+ To dump the jlink/post_verilog/header/binary file: \n\
+\t>ql_symbiflow -compile -src <source_dir path> -d <device> -P <package> -t <top> -v <verilog file/files> -p <pcf file> -dump <jlink/post_verilog/header/openocd/binary> \n\
 Device supported:ql-eos-s3\n\
 Packages supported PD64,PU64,WR42 " || exit 1
 elif [[ $1 == "-v" || $1 == "--version" ]];then
@@ -383,13 +383,13 @@ SDC := $SDC_MAKE\n\
 BUILDDIR := build\n\n\
 all: \${BUILDDIR}/\${TOP}.bit\n\
 \n\
-\${BUILDDIR}/\${TOP}.eblif: \${VERILOG} \${PCF}\n\
+\${BUILDDIR}/\${TOP}.eblif: \${VERILOG}\n\
 	cd \${BUILDDIR} && symbiflow_synth -t \${TOP} -v \${VERILOG} -d \${DEVICE} -p \${PCF} -P \${PART} 2>&1 > $LOG_FILE\n\
 \n\
 \${BUILDDIR}/\${TOP}.net: \${BUILDDIR}/\${TOP}.eblif\n\
 	cd \${BUILDDIR} && symbiflow_pack -e \${TOP}.eblif -d \${DEVICE} -s \${SDC} 2>&1 > $LOG_FILE\n\
 \n\
-\${BUILDDIR}/\${TOP}.place: \${BUILDDIR}/\${TOP}.net \${PCF}\n\
+\${BUILDDIR}/\${TOP}.place: \${BUILDDIR}/\${TOP}.net\n\
 	cd \${BUILDDIR} && symbiflow_place -e \${TOP}.eblif -d \${DEVICE} -p \${PCF} -n \${TOP}.net -P \${PARTNAME} -s \${SDC} 2>&1 > $LOG_FILE\n\
 \n\
 \${BUILDDIR}/\${TOP}.route: \${BUILDDIR}/\${TOP}.place\n\
@@ -403,6 +403,9 @@ all: \${BUILDDIR}/\${TOP}.bit\n\
 \n\
 \${BUILDDIR}/\${TOP}_bit.h: \${BUILDDIR}/\${TOP}.bit\n\
 	cd \${BUILDDIR} && symbiflow_write_bitheader -b \${TOP}.bit\n\
+\n\
+\${BUILDDIR}/\${TOP}.bin: \${BUILDDIR}/\${TOP}.bit\n\
+	cd \${BUILDDIR} && symbiflow_write_binary -b \${TOP}.bit\n\
 \n\
 \${BUILDDIR}/\${TOP}.jlink: \${BUILDDIR}/\${TOP}.bit\n\
 	cd \${BUILDDIR} && symbiflow_write_jlink -f \${TOP}.fasm -P \${PACKAGENAME} -b \${TOP}.bit\n\
@@ -440,6 +443,9 @@ elif [[ ! -z "$OUT" && $1 == "-compile" ]];then
    fi
    if [[ " ${OUT_ARR[@]} " =~ " header " ]]; then
     cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}_bit.h || exit
+   fi
+   if [[ " ${OUT_ARR[@]} " =~ " binary " ]]; then
+    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bin || exit
    fi
 else
  if [ $1 == "-compile" ]; then

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -383,13 +383,13 @@ SDC := $SDC_MAKE\n\
 BUILDDIR := build\n\n\
 all: \${BUILDDIR}/\${TOP}.bit\n\
 \n\
-\${BUILDDIR}/\${TOP}.eblif: \${VERILOG}\n\
+\${BUILDDIR}/\${TOP}.eblif: \${VERILOG} \${PCF}\n\
 	cd \${BUILDDIR} && symbiflow_synth -t \${TOP} -v \${VERILOG} -d \${DEVICE} -p \${PCF} -P \${PART} 2>&1 > $LOG_FILE\n\
 \n\
 \${BUILDDIR}/\${TOP}.net: \${BUILDDIR}/\${TOP}.eblif\n\
 	cd \${BUILDDIR} && symbiflow_pack -e \${TOP}.eblif -d \${DEVICE} -s \${SDC} 2>&1 > $LOG_FILE\n\
 \n\
-\${BUILDDIR}/\${TOP}.place: \${BUILDDIR}/\${TOP}.net\n\
+\${BUILDDIR}/\${TOP}.place: \${BUILDDIR}/\${TOP}.net \${PCF}\n\
 	cd \${BUILDDIR} && symbiflow_place -e \${TOP}.eblif -d \${DEVICE} -p \${PCF} -n \${TOP}.net -P \${PARTNAME} -s \${SDC} 2>&1 > $LOG_FILE\n\
 \n\
 \${BUILDDIR}/\${TOP}.route: \${BUILDDIR}/\${TOP}.place\n\

--- a/quicklogic/common/toolchain_wrappers/symbiflow_generate_constraints
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_generate_constraints
@@ -32,8 +32,10 @@ IOPLACE_FILE="${PROJECT%.*}_io.place"
 PLACE_FILE="${PROJECT%.*}_constraints.place"
 IOMUX_JLINK="${PROJECT%.*}_iomux.jlink"
 IOMUX_OPENOCD="${PROJECT%.*}_iomux.openocd"
+IOMUX_BINARY="${PROJECT%.*}_iomux.bin"
 
 python3 ${IOGEN} --pcf $PCF --blif $EBLIF --map $PINMAP --net $NET > ${IOPLACE_FILE}
 python3 ${PLACEGEN} --blif $EBLIF --map $CLKMAP -i ${IOPLACE_FILE} > ${PLACE_FILE}
 python3 ${CONSTR_GEN} --eblif $EBLIF --pcf $PCF --map $PINMAP --output-format=jlink > ${IOMUX_JLINK}
 python3 ${CONSTR_GEN} --eblif $EBLIF --pcf $PCF --map $PINMAP --output-format=openocd > ${IOMUX_OPENOCD}
+python3 ${CONSTR_GEN} --eblif $EBLIF --pcf $PCF --map $PINMAP --output-format=binary > ${IOMUX_BINARY}

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_binary
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_binary
@@ -6,7 +6,7 @@ MYPATH=$(dirname "$(readlink -f "$BASH_SOURCE")")
 
 source ${MYPATH}/env
 
-JLINK2BINARY=`readlink -f ${MYPATH}/../bin/python/bitstream_to_binary.py`
+BIT2BINARY=`readlink -f ${MYPATH}/../bin/python/bitstream_to_binary.py`
 
 
-python3 ${JLINK2BINARY} ${TOP_F}.bit ../${TOP_F}.bin
+python3 ${BIT2BINARY} ${TOP_F}.bit ../${TOP_F}.bin

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_binary
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_binary
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+MYPATH=$(dirname "$(readlink -f "$BASH_SOURCE")")
+
+
+source ${MYPATH}/env
+
+JLINK2BINARY=`readlink -f ${MYPATH}/../bin/python/bitstream_to_binary.py`
+
+
+python3 ${JLINK2BINARY} ${TOP_F}.bit ../${TOP_F}.bin

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_jlink
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_jlink
@@ -9,7 +9,4 @@ source ${MYPATH}/env
 BIT2JLINK=`readlink -f ${MYPATH}/../bin/python/bitstream_to_jlink.py`
 
 echo "Generating bit.jlink"
-python3 ${BIT2JLINK} ${TOP_F}.bit ${TOP_F}.bit.jlink
-
-echo "Generating jlink file"
-cat ${TOP_F}.bit.jlink ${TOP_F}_iomux.jlink > ../${TOP_F}.jlink
+python3 ${BIT2JLINK} ${TOP_F}.bit ../${TOP_F}.jlink

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_openocd
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_openocd
@@ -9,7 +9,4 @@ source ${MYPATH}/env
 BIT2OPENOCD=`readlink -f ${MYPATH}/../bin/python/bitstream_to_openocd.py`
 
 echo "Generating bit.openocd"
-python3 ${BIT2OPENOCD} ${TOP_F}.bit ${TOP_F}.bit.openocd
-
-echo "Generating openocd file"
-cat ${TOP_F}.bit.openocd ${TOP_F}_iomux.openocd > ../${TOP_F}.openocd
+python3 ${BIT2OPENOCD} ${TOP_F}.bit ../${TOP_F}.openocd

--- a/quicklogic/common/utils/eos_s3_iomux_config.py
+++ b/quicklogic/common/utils/eos_s3_iomux_config.py
@@ -300,17 +300,28 @@ def main():
     # Convert the config to IOMUX register content
     iomux_regs = generate_iomux_register_content(config)
 
-    print("")
-    if args.output_format == "openocd":
+    if args.output_format == "openocd":        
         # Output openOCD process
         for adr in sorted(iomux_regs.keys()):
-            print("    mww 0x{:08X} 0x{:08X}".format(adr, iomux_regs[adr]))
-    elif args.output_format == "jlink":
+            print("    mww 0x{:08x} 0x{:08x}".format(adr, iomux_regs[adr]))
+    elif args.output_format == "jlink":        
         # Output JLink commands
         for adr in sorted(iomux_regs.keys()):
-            print("w4 0x{:08X} 0x{:08X}".format(adr, iomux_regs[adr]))
+            print("w4 0x{:08x} 0x{:08x}".format(adr, iomux_regs[adr]))
+    elif args.output_format == "binary":
+        # Output binary file: <REGADDR 4B><REGVAL 4B>...
+        for adr in sorted(iomux_regs.keys()):
+            #print("0x{:08X}0x{:08X}".format(adr, iomux_regs[adr]))
+            # first the address
+            addr_bytes = int(adr).to_bytes(4,byteorder='little')
+            # output the address as raw bytes, bypass the print(), LE, 4B
+            sys.stdout.buffer.write(addr_bytes)
+            # second the value
+            val_bytes = int(iomux_regs[adr]).to_bytes(4,byteorder='little')
+            # output the value as raw bytes, bypass the print(), LE, 4B
+            sys.stdout.buffer.write(val_bytes)
     else:
-        print("Use either 'openocd' or 'jlink' output format!")
+        print("Use either 'openocd' or 'jlink' or 'binary' output format!")
         exit(-1)
 
 


### PR DESCRIPTION
This is PR-2 for the fpga-bootloading-changes-phase-1.
Summary of changes:
- add `symbiflow_write_binary` toolchain wrapper script
- modify `eos_s3_iomux_config.py` to add support for binary output and fix extra newlines in jlink and openocd iomux generation
- modify `symbiflow_write_jlink` `symbiflow_write_openocd` wrapper to streamline (along with PR-1 in fasm repo)
- modify `symbiflow_generate_constraints` wrapper to add support for iomux binary generation
- modify `ql_symbiflow` wrapper to add support for fpga binary generation

One more changes is pending before this PR can be merged:
- the PR-1 for the fasm repo (https://github.com/QuickLogic-Corp/quicklogic-fasm/pull/6) needs to be merged to master
- the fasm submodule of this repo needs to be updated to the new version after PR-1 is merged

Once that is done, we will change this from a draft PR to PR and can then merge is review is ok.