### PR TITLE
Fix for fasm2bels behavior for bitstreams with default mux configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ setup_env(
 add_conda_package(
   NAME yosys
   PROVIDES yosys
-  PACKAGE_SPEC "quicklogic-yosys v0.8.0_75_g3609a7d9 20210127_093658"
+  PACKAGE_SPEC "quicklogic-yosys 0.8.0_103_ga920ab6b 20210310_194315"
   )
 
 add_conda_package(

--- a/quicklogic/common/utils/fasm2bels.py
+++ b/quicklogic/common/utils/fasm2bels.py
@@ -699,8 +699,9 @@ class Fasm2Bels(object):
             # Group GMUX input pin connections by GMUX cell names
             gmux_connections = defaultdict(lambda: dict())
             for cell_pin, conn in self.designconnections[loc].items():
-                cell, pin = cell_pin.split("_", maxsplit=1)
-                gmux_connections[cell][pin] = conn
+                if cell_pin.startswith("GMUX"):
+                    cell, pin = cell_pin.split("_", maxsplit=1)
+                    gmux_connections[cell][pin] = conn
 
             # Examine each GMUX config
             for gmux, connections in gmux_connections.items():
@@ -793,8 +794,9 @@ class Fasm2Bels(object):
             # Group QMUX input pin connections by QMUX cell names
             qmux_connections = defaultdict(lambda: dict())
             for cell_pin, conn in self.designconnections[loc].items():
-                cell, pin = cell_pin.split("_", maxsplit=1)
-                qmux_connections[cell][pin] = conn
+                if cell_pin.startswith("QMUX"):
+                    cell, pin = cell_pin.split("_", maxsplit=1)
+                    qmux_connections[cell][pin] = conn
 
             # Examine each QMUX config
             for qmux, connections in qmux_connections.items():

--- a/quicklogic/common/utils/verilogmodule.py
+++ b/quicklogic/common/utils/verilogmodule.py
@@ -194,6 +194,8 @@ class VModule(object):
             assign = "    assign {} = {};".format(parameters["IZ"], ioname)
         elif direction == 'output':
             assign = "    assign {} = {};".format(ioname, parameters["OQI"])
+        elif direction is None:
+            pass
         else:
             assert False, "Unknown IO configuration"
 
@@ -218,8 +220,12 @@ class VModule(object):
         str: Verilog entry
         '''
         if typ == 'BIDIR':
+
             # We do not emit the BIDIR cell for non inout IOs
-            if self.get_io_config(parameters) != 'inout':
+            direction = self.get_io_config(parameters)
+            if direction is None:
+                return ""
+            elif direction != 'inout':
                 return self.form_simple_assign(loc, parameters)
 
         params = []
@@ -617,7 +623,7 @@ class VModule(object):
         elif output_en:
             direction = 'output'
         else:
-            assert False, "Unknown IO configuration"
+            direction = None
 
         return direction
 
@@ -637,10 +643,12 @@ class VModule(object):
                     else:
                         direction = self.get_io_config(element.ios)
 
-                    name = self.get_io_name(eloc)
-                    self.ios[eloc] = VerilogIO(
-                        name=name, direction=direction, ioloc=eloc
-                    )
+                    # Add the input if used
+                    if direction is not None:
+                        name = self.get_io_name(eloc)
+                        self.ios[eloc] = VerilogIO(
+                            name=name, direction=direction, ioloc=eloc
+                        )
 
                     # keep the original wire name for generating the wireid
                     #wireid = Wire(name, "inout_pin", False)

--- a/quicklogic/common/utils/verilogmodule.py
+++ b/quicklogic/common/utils/verilogmodule.py
@@ -190,6 +190,9 @@ class VModule(object):
 
         assign = ""
         direction = self.get_io_config(parameters)
+
+        print(direction, bloc, ioname, parameters)
+
         if direction == 'input':
             assign = "    assign {} = {};".format(parameters["IZ"], ioname)
         elif direction == 'output':
@@ -660,6 +663,11 @@ class VModule(object):
             direction = 'output'
         else:
             direction = None
+
+        # Output unrouted. Discard
+        if direction == 'input':
+            if 'IZ' not in ios:
+                return None
 
         return direction
 

--- a/quicklogic/pp3/tests/CMakeLists.txt
+++ b/quicklogic/pp3/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_custom_target(all_ql_tests_bit_v)
 add_custom_target(all_ql_tests_bit)
 add_custom_target(all_ql_tests_prog)
 
@@ -5,6 +6,7 @@ add_dependencies(all_ql_tests_prog all_ql_tests_bit)
 
 add_custom_target(all_ql_tests)
 add_dependencies(all_ql_tests all_ql_tests_bit)
+add_dependencies(all_ql_tests all_ql_tests_bit_v)
 
 add_custom_target(all_quick_tests)
 

--- a/quicklogic/pp3/tests/bram/CMakeLists.txt
+++ b/quicklogic/pp3/tests/bram/CMakeLists.txt
@@ -18,6 +18,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit bram-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v bram-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog bram-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog bram-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
@@ -24,6 +24,7 @@ add_dependencies(all_quick_tests btn_counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests btn_counter-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit btn_counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v btn_counter-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_openocd)
 
@@ -45,6 +46,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit btn_counter-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_bit_v btn_counter-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
@@ -22,6 +22,7 @@ add_dependencies(all_quick_tests btn_ff-ql-chandalar_jlink)
 add_dependencies(all_quick_tests btn_ff-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit btn_ff-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v btn_ff-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
@@ -22,6 +22,7 @@ add_dependencies(all_quick_tests btn_xor-ql-chandalar_jlink)
 add_dependencies(all_quick_tests btn_xor-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit btn_xor-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v btn_xor-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/counter/CMakeLists.txt
@@ -23,6 +23,7 @@ add_dependencies(all_quick_tests counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests counter-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v counter-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog counter-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog counter-ql-chandalar_openocd)
 
@@ -44,6 +45,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit counter-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_bit_v counter-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog counter-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog counter-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
@@ -22,6 +22,7 @@ add_dependencies(all_quick_tests ext_counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests ext_counter-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit ext_counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v ext_counter-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_openocd)
 
@@ -45,6 +46,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit ext_counter-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_bit_v ext_counter-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/gclk_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/gclk_counter/CMakeLists.txt
@@ -20,6 +20,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit gclk_counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v gclk_counter-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog gclk_counter-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog gclk_counter-ql-chandalar_openocd)
 add_dependencies(all_quick_tests gclk_counter-ql-chandalar_analysis)

--- a/quicklogic/pp3/tests/mult/CMakeLists.txt
+++ b/quicklogic/pp3/tests/mult/CMakeLists.txt
@@ -22,6 +22,7 @@ add_dependencies(all_quick_tests mult-ql-chandalar_jlink)
 add_dependencies(all_quick_tests mult-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit mult-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v mult-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog mult-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog mult-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/Simon_bit_serial_top_module/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/Simon_bit_serial_top_module/CMakeLists.txt
@@ -22,6 +22,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  simon-bit-serial-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v simon-bit-serial-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog simon-bit-serial-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog simon-bit-serial-ql-chandalar_openocd)
 add_dependencies(all_quick_tests simon-bit-serial-ql-chandalar_analysis)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/bin2seven/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/bin2seven/CMakeLists.txt
@@ -18,5 +18,6 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  bin2seven-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v bin2seven-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog bin2seven-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog bin2seven-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/camif/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/camif/CMakeLists.txt
@@ -19,6 +19,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  camif-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v camif-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog camif-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog camif-ql-chandalar_openocd)
 add_dependencies(all_quick_tests camif-ql-chandalar_analysis)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/clock_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/clock_test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  clock_test-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v clock_test-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog clock_test-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog clock_test-ql-chandalar_openocd)
 add_dependencies(all_quick_tests clock_test-ql-chandalar_analysis)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/clock_tree_design/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/clock_tree_design/CMakeLists.txt
@@ -18,5 +18,6 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  clock-tree-design-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v clock-tree-design-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog clock-tree-design-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog clock-tree-design-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/counter_16bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/counter_16bit/CMakeLists.txt
@@ -20,6 +20,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  counter_16bit-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v counter_16bit-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog counter_16bit-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog counter_16bit-ql-chandalar_openocd)
 add_dependencies(all_quick_tests counter_16bit-ql-chandalar_analysis)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/counter_32bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/counter_32bit/CMakeLists.txt
@@ -18,6 +18,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  counter_32bit-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v counter_32bit-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog counter_32bit-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog counter_32bit-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/counter_8bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/counter_8bit/CMakeLists.txt
@@ -18,6 +18,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  counter_8bit-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v counter_8bit-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog counter_8bit-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog counter_8bit-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/counter_al4s3b/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/counter_al4s3b/CMakeLists.txt
@@ -24,5 +24,6 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  counter_al4s3b-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v counter_al4s3b-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog counter_al4s3b-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog counter_al4s3b-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design1/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design1/CMakeLists.txt
@@ -34,6 +34,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  design1-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v design1-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog design1-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog design1-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design10/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design10/CMakeLists.txt
@@ -25,6 +25,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  design10-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v design10-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog design10-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog design10-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design2/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design2/CMakeLists.txt
@@ -36,6 +36,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  design2-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v design2-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog design2-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog design2-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design3/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design3/CMakeLists.txt
@@ -31,5 +31,6 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  design3-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v design3-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog design3-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog design3-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design6/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design6/CMakeLists.txt
@@ -24,6 +24,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  design6-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v design6-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog design6-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog design6-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design8/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design8/CMakeLists.txt
@@ -35,6 +35,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  design8-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v design8-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog design8-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog design8-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/design9/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/design9/CMakeLists.txt
@@ -26,6 +26,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  design9-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v design9-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog design9-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog design9-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/fifo_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/fifo_test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  fifo_test-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v fifo_test-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog fifo_test-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog fifo_test-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/i2c_master_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/i2c_master_top/CMakeLists.txt
@@ -22,6 +22,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  i2c_master_top-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v i2c_master_top-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog i2c_master_top-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog i2c_master_top-ql-chandalar_openocd)
 add_dependencies(all_quick_tests i2c_master_top-ql-chandalar_analysis)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/jpeg_qnr/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/jpeg_qnr/CMakeLists.txt
@@ -21,6 +21,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit jpeg-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v jpeg-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog jpeg-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog jpeg-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/mult_8bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/mult_8bit/CMakeLists.txt
@@ -20,6 +20,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  mult_8bit-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v mult_8bit-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog mult_8bit-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog mult_8bit-ql-chandalar_openocd)
 add_dependencies(all_quick_tests mult_8bit-ql-chandalar_analysis)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/osc_alu/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/osc_alu/CMakeLists.txt
@@ -22,6 +22,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  osc_alu-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v osc_alu-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog osc_alu-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog osc_alu-ql-chandalar_openocd)
 add_dependencies(all_quick_tests osc_alu-ql-chandalar_analysis)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/ram_test/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/ram_test/CMakeLists.txt
@@ -40,6 +40,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  ram_test-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v ram_test-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog ram_test-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog ram_test-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/rgb2ycrcb/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/rgb2ycrcb/CMakeLists.txt
@@ -18,6 +18,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  rgb2ycrcb-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v rgb2ycrcb-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog rgb2ycrcb-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog rgb2ycrcb-ql-chandalar_openocd)
 
@@ -40,6 +41,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  rgb2ycrcb-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_bit_v rgb2ycrcb-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog rgb2ycrcb-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog rgb2ycrcb-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/rs_decoder_1/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/rs_decoder_1/CMakeLists.txt
@@ -18,6 +18,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  rs-decoder-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v rs-decoder-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog rs-decoder-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog rs-decoder-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/spi_master_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/spi_master_top/CMakeLists.txt
@@ -23,5 +23,6 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  spi_master_top-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v spi_master_top-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog spi_master_top-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog spi_master_top-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/test_logic_cell/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/test_logic_cell/CMakeLists.txt
@@ -18,5 +18,6 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  test_logic_cell-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v test_logic_cell-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog test_logic_cell-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog test_logic_cell-ql-chandalar_openocd)

--- a/quicklogic/pp3/tests/quicklogic_testsuite/top_120_13/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/top_120_13/CMakeLists.txt
@@ -18,6 +18,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  top-120-13-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v top-120-13-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog top-120-13-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog top-120-13-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/quicklogic_testsuite/wbqspiflash/CMakeLists.txt
+++ b/quicklogic/pp3/tests/quicklogic_testsuite/wbqspiflash/CMakeLists.txt
@@ -22,6 +22,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  wbqspiflash-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v wbqspiflash-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog wbqspiflash-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog wbqspiflash-ql-chandalar_openocd)
 
@@ -44,6 +45,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  wbqspiflash-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_bit_v wbqspiflash-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog wbqspiflash-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog wbqspiflash-ql-quickfeather_openocd)
 

--- a/quicklogic/pp3/tests/ram/CMakeLists.txt
+++ b/quicklogic/pp3/tests/ram/CMakeLists.txt
@@ -22,6 +22,7 @@ add_dependencies(all_quick_tests ram-ql-chandalar_jlink)
 add_dependencies(all_quick_tests ram-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit ram-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v ram-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog ram-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog ram-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/sdiomux_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/sdiomux_counter/CMakeLists.txt
@@ -22,6 +22,7 @@ add_dependencies(all_quick_tests sdiomux-counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests sdiomux-counter-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit sdiomux-counter-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v sdiomux-counter-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog sdiomux-counter-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog sdiomux-counter-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
@@ -22,6 +22,7 @@ add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_jlink)
 add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit sdiomux_xor-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v sdiomux_xor-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_openocd)
 

--- a/quicklogic/pp3/tests/soc_clocks/CMakeLists.txt
+++ b/quicklogic/pp3/tests/soc_clocks/CMakeLists.txt
@@ -22,6 +22,7 @@ add_dependencies(all_quick_tests soc_clocks-ql-chandalar_jlink)
 add_dependencies(all_quick_tests soc_clocks-ql-chandalar_openocd)
 
 add_dependencies(all_ql_tests_bit soc_clocks-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v soc_clocks-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog soc_clocks-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog soc_clocks-ql-chandalar_openocd)
 add_dependencies(all_quick_tests soc_clocks-ql-chandalar_analysis)
@@ -47,5 +48,6 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  soc_clocks-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_bit_v soc_clocks-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog soc_clocks-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog soc_clocks-ql-quickfeather_openocd)

--- a/quicklogic/pp3/tests/soc_litex_pwm/CMakeLists.txt
+++ b/quicklogic/pp3/tests/soc_litex_pwm/CMakeLists.txt
@@ -19,6 +19,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  soc_litex_pwm-ql-chandalar_bit)
+add_dependencies(all_ql_tests_bit_v soc_litex_pwm-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog soc_litex_pwm-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog soc_litex_pwm-ql-chandalar_openocd)
 
@@ -41,6 +42,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_ql_tests_bit  soc_litex_pwm-ql-quickfeather_bit)
+add_dependencies(all_ql_tests_bit_v soc_litex_pwm-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog soc_litex_pwm-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog soc_litex_pwm-ql-quickfeather_openocd)
 


### PR DESCRIPTION
This PR fixes `fasm2bels` plus adds targets that invoke it to the GitHub CI.