### PR TITLE
quicklogic: add support to generate bitstream with the toolchain

### DIFF
--- a/quicklogic/common/cmake/quicklogic_install.cmake
+++ b/quicklogic/common/cmake/quicklogic_install.cmake
@@ -23,7 +23,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
     return()
   endif ()
 
-  set(WRAPPERS env symbiflow_generate_constraints symbiflow_pack symbiflow_place symbiflow_route symbiflow_synth ql_symbiflow symbiflow_analysis symbiflow_repack)
+  set(WRAPPERS env symbiflow_generate_constraints symbiflow_pack symbiflow_place symbiflow_route symbiflow_synth ql_symbiflow symbiflow_analysis symbiflow_repack symbiflow_write_fasm symbiflow_generate_bitstream)
 
   # Export VPR arguments
   list(JOIN VPR_BASE_ARGS " " VPR_BASE_ARGS)
@@ -66,7 +66,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/tests/counter_16bit/counter_16bit.sdc
           DESTINATION share/symbiflow/tests/counter_16bit
           PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
-  
+
   # install python scripts
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/split_inouts.py
           DESTINATION bin/python
@@ -126,6 +126,9 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/utils/create_ioplace.py
           DESTINATION bin/python
           PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
+
+  install(DIRECTORY ${QLF_FPGA_DATABASE_DIR}/${FAMILY}/fasm_database/
+          DESTINATION share/symbiflow/fasm_database/${FAMILY})
 
 endfunction()
 

--- a/quicklogic/common/toolchain_wrappers/conda_build_install_package.sh
+++ b/quicklogic/common/toolchain_wrappers/conda_build_install_package.sh
@@ -25,7 +25,7 @@ conda update $CONDA_FLAGS -q conda
 curl https://storage.googleapis.com/symbiflow-arch-defs-install/quicklogic-arch-defs-63c3d8f9.tar.gz --output arch.tar.gz
 tar -C $INSTALL_DIR -xvf arch.tar.gz && rm arch.tar.gz
 conda install $CONDA_FLAGS -c litex-hub/label/main yosys="0.9_5266_g0fb4224e 20210301_104249_py37"
-conda install $CONDA_FLAGS -c litex-hub/label/main symbiflow-yosys-plugins="1.0.0_7_284_gb6c5f5d 20210318_102115"
+conda install $CONDA_FLAGS -c litex-hub/label/main symbiflow-yosys-plugins="1.0.0_7_307_gc14d794=20210420_072542"
 conda install $CONDA_FLAGS -c litex-hub/label/main vtr-optimized="8.0.0_3452_ge7d45e013 20210318_102115"
 conda install $CONDA_FLAGS -c litex-hub iverilog
 conda install $CONDA_FLAGS -c tfors gtkwave
@@ -34,4 +34,5 @@ conda activate
 pip install python-constraint
 pip install serial
 pip install git+https://github.com/QuickLogic-Corp/quicklogic-fasm@318abca
+pip install git+https://github.com/QuickLogic-Corp/ql_fasm@e7d0f2fdf5c404b621b24e78fdea51fcb1937672
 conda deactivate

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -416,7 +416,7 @@ PCF := $PCF_MAKE\n\
 SDC := $SDC_MAKE\n\
 BUILDDIR := build\n\n\
 
-all: \${BUILDDIR}/\${TOP_FINAL}.route\n\
+all: \${BUILDDIR}/\${TOP}.bit\n\
 \n\
 \${BUILDDIR}/\${TOP}.eblif: \${VERILOG} \${PCF}\n\
   ifneq (\"\$(wildcard \$(HEX_FILES))\",\"\")\n\
@@ -444,6 +444,12 @@ fi
 \n\
 \${BUILDDIR}/\${TOP}.post_v: \${BUILDDIR}/\${TOP_FINAL}.route\n\
 	cd \${BUILDDIR} && symbiflow_analysis -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} 2>&1 > $LOG_FILE\n\
+\n\
+\${BUILDDIR}/\${TOP}.fasm: \${BUILDDIR}/\${TOP_FINAL}.route\n\
+	cd \${BUILDDIR} && symbiflow_write_fasm -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} 2>&1 > $LOG_FILE\n\
+\n\
+\${BUILDDIR}/\${TOP}.bit: \${BUILDDIR}/\${TOP}.fasm\n\
+	cd \${BUILDDIR} && symbiflow_generate_bitstream -d \${FAMILY} -f \${TOP}.fasm -b \${TOP}.bit 2>&1 > $LOG_FILE\n\
 " >>$MAKE_FILE
 
 if [ "$HAVE_FASM2BELS" != 0 ]; then
@@ -470,13 +476,8 @@ elif [[ ! -z "$OUT" && $1 == "-compile" ]];then
 	fi
 else
   if [ $1 == "-compile" ]; then
-  echo -e "Running Synth->Pack->Place->Route"
-  # FIXME: No bitstream for qlf_k4n8
-	  if [ "${FAMILY}" == "qlf_k4n8" ]; then
-    		cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP_FINAL}.route  || exit
-  	  else
-    		cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP_FINAL}.bit  || exit
-  	  fi
+  echo -e "Running Synth->Pack->Place->Route->FASM->bitstream"
+  	cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bit  || exit
   fi
 fi
 

--- a/quicklogic/common/toolchain_wrappers/symbiflow_generate_bitstream
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_generate_bitstream
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+MYPATH=`realpath $0`
+MYPATH=`dirname ${MYPATH}`
+
+OPTS=d:f:b:
+LONGOPTS=device:,fasm:,bit:
+
+PARSED_OPTS=`getopt --options=${OPTS} --longoptions=${LONGOPTS} --name $0 -- "$@"`
+eval set -- "${PARSED_OPTS}"
+
+DEVICE=""
+FASM=""
+BIT=""
+
+while true; do
+	case "$1" in
+		-d|--device)
+			DEVICE=$2
+			shift 2
+			;;
+		-f|--fasm)
+			FASM=$2
+			shift 2
+			;;
+		-b|--bit)
+			BIT=$2
+			shift 2
+			;;
+		--)
+			break
+			;;
+	esac
+done
+
+if [ -z $DEVICE ]; then
+		echo "Please provide device name"
+		exit 1
+fi
+
+if [ -z $FASM ]; then
+		echo "Please provide an input FASM file name"
+		exit 1
+fi
+
+if [ -z $BIT ]; then
+		echo "Please provide an output bistream file name"
+		exit 1
+fi
+
+QLF_FASM=`which qlf_fasm`
+
+DB_ROOT=`realpath ${MYPATH}/../share/symbiflow/fasm_database/${DEVICE}`
+
+${QLF_FASM} --db-root ${DB_ROOT} --assemble $FASM $BIT
+

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_fasm
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_fasm
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+MYPATH=`realpath $0`
+MYPATH=`dirname ${MYPATH}`
+
+source ${MYPATH}/env
+source ${VPRPATH}/vpr_common
+
+parse_args "$@"
+
+TOP="${EBLIF%.*}"
+FASM_EXTRA=${TOP}_fasm_extra.fasm
+
+export OUT_NOISY_WARNINGS=noisy_warnings-${DEVICE}_fasm.log
+
+run_genfasm
+
+echo "FASM extra: $FASM_EXTRA"
+if [ -f $FASM_EXTRA ]; then
+	echo "writing final fasm"
+	cat ${TOP}.fasm $FASM_EXTRA > tmp.fasm
+	mv tmp.fasm ${TOP}.fasm
+fi
+
+mv vpr_stdout.log fasm.log


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds support to write the bitstream and FASM to the installed toolchain.