### PR TITLE
Writing bitstream in OpenFPGA format

### DIFF
--- a/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
+++ b/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
@@ -79,10 +79,21 @@ function(QUICKLOGIC_DEFINE_QLF_ARCH)
       \${QUIET_CMD} \${FASM_TO_BIT} \
         --db-root ${QLF_FPGA_DATABASE_DIR}/${ARCH}/fasm_database \
         --assemble \
+        --format 4byte \
         \${OUT_FASM} \
         \${OUT_BITSTREAM} "
 
-    NO_BIT_TO_BIN
+    BIN_EXTENSION bin
+    BIT_TO_BIN ${QLF_FASM}
+    BIT_TO_BIN_CMD "${CMAKE_COMMAND} -E env \
+      PYTHONPATH=${symbiflow-arch-defs_BINARY_DIR}/env/conda/lib/python3.7/site-packages \
+      \${QUIET_CMD} \${FASM_TO_BIT} \
+        --db-root ${QLF_FPGA_DATABASE_DIR}/${ARCH}/fasm_database \
+        --assemble \
+        --format txt \
+        \${OUT_FASM} \
+        \${OUT_BIN} "
+
     NO_BIT_TO_V
     NO_BIT_TIME
     USE_FASM

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -449,7 +449,8 @@ fi
 	cd \${BUILDDIR} && symbiflow_write_fasm -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} 2>&1 > $LOG_FILE\n\
 \n\
 \${BUILDDIR}/\${TOP}.bit: \${BUILDDIR}/\${TOP}.fasm\n\
-	cd \${BUILDDIR} && symbiflow_generate_bitstream -d \${FAMILY} -f \${TOP}.fasm -b \${TOP}.bit 2>&1 > $LOG_FILE\n\
+	cd \${BUILDDIR} && symbiflow_generate_bitstream -d \${FAMILY} -f \${TOP}.fasm -r 4byte -b \${TOP}.bit 2>&1 > $LOG_FILE\n\
+	cd \${BUILDDIR} && symbiflow_generate_bitstream -d \${FAMILY} -f \${TOP}.fasm -r txt -b \${TOP}.bin 2>&1 > $LOG_FILE\n\
 " >>$MAKE_FILE
 
 if [ "$HAVE_FASM2BELS" != 0 ]; then

--- a/quicklogic/common/toolchain_wrappers/symbiflow_generate_bitstream
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_generate_bitstream
@@ -4,8 +4,8 @@ set -e
 MYPATH=`realpath $0`
 MYPATH=`dirname ${MYPATH}`
 
-OPTS=d:f:b:
-LONGOPTS=device:,fasm:,bit:
+OPTS=d:f:r:b:
+LONGOPTS=device:,fasm:,format:,bit:
 
 PARSED_OPTS=`getopt --options=${OPTS} --longoptions=${LONGOPTS} --name $0 -- "$@"`
 eval set -- "${PARSED_OPTS}"
@@ -13,6 +13,7 @@ eval set -- "${PARSED_OPTS}"
 DEVICE=""
 FASM=""
 BIT=""
+BIT_FORMAT="4byte"
 
 while true; do
 	case "$1" in
@@ -22,6 +23,10 @@ while true; do
 			;;
 		-f|--fasm)
 			FASM=$2
+			shift 2
+			;;
+		-r|--format)
+			BIT_FORMAT=$2
 			shift 2
 			;;
 		-b|--bit)
@@ -53,5 +58,5 @@ QLF_FASM=`which qlf_fasm`
 
 DB_ROOT=`realpath ${MYPATH}/../share/symbiflow/fasm_database/${DEVICE}`
 
-${QLF_FASM} --db-root ${DB_ROOT} --assemble $FASM $BIT
+${QLF_FASM} --db-root ${DB_ROOT} --format ${BIT_FORMAT} --assemble $FASM $BIT
 


### PR DESCRIPTION
This PR adds bitstream output in OpenFPGA text format parallel to the output in 4byte format. It is added both to the CMake flow and installed toolchain.