### PR TITLE
Temporary fix for fasm warnings

### DIFF
--- a/quicklogic/common/toolchain_wrappers/conda_build_install_package.sh
+++ b/quicklogic/common/toolchain_wrappers/conda_build_install_package.sh
@@ -33,6 +33,7 @@ conda install $CONDA_FLAGS make lxml simplejson intervaltree git pip
 conda activate
 pip install python-constraint
 pip install serial
+pip install git+https://github.com/antmicro/fasm@fa9a02bd84f4bb93da8476e5718517216ec78d1f#egg=fasm # Install fasm with print() instead of warn()
 pip install git+https://github.com/QuickLogic-Corp/quicklogic-fasm@318abca
 pip install git+https://github.com/QuickLogic-Corp/ql_fasm@e7d0f2fdf5c404b621b24e78fdea51fcb1937672
 conda deactivate

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,8 @@ textx
 tinyfpgab
 tinyprog
 yapf==0.26.0
-fasm
+#fasm
+git+https://github.com/antmicro/fasm@fa9a02bd84f4bb93da8476e5718517216ec78d1f#egg=fasm
 git+https://github.com/SymbiFlow/symbiflow-rr-graph.git#egg=rr-graph
 git+https://github.com/SymbiFlow/python-fpga-interchange.git#egg=python-fpga-interchange
 -e third_party/prjxray


### PR DESCRIPTION
This PR changes the `fasm` version used to the one from a pending PR: https://github.com/SymbiFlow/fasm/pull/70 It will still emit a warning for missing `antlr` parser but the message will be redirected to the log.