### PR TITLE
quicklogic: keep using top IO ports after repacking

### DIFF
--- a/quicklogic/qlf_k4n8/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/CMakeLists.txt
@@ -14,12 +14,19 @@ add_subdirectory(techmap)
 # consider it. Each tile has a separate clock input multiplexer. Its selection
 # is established during the VPR packing stage.
 #
+# TODO: The LUT buffer absorption is currently turned off as the repacker
+#       inserts some LUT buffers to allow maintaining the top level IO ports.
+#       With the LUT buffer absorption enabled, the patched netlist and blif
+#       out of the repacker will be out of sync, causing a VPR failure. The solution
+#       likely requires a revision of the repacker code to correctly and robustly
+#       handle the top level I/Os.
 set(VPR_ARCH_ARGS "\
     --clock_modeling ideal \
     --place_delta_delay_matrix_calculation_method dijkstra \
     --place_delay_model delta_override \
     --router_lookahead extended_map \
-    --allow_dangling_combinational_nodes on "
+    --allow_dangling_combinational_nodes on \
+    --absorb_buffer_luts off "
 )
 
 # Define the architecture

--- a/quicklogic/qlf_k4n8/tests/counter/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/counter/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_file_target(FILE counter.v SCANNER_TYPE verilog)
+add_file_target(FILE counter.sdc SCANNER_TYPE)
 add_file_target(FILE test.pcf)
 
 add_fpga_target(
@@ -7,6 +8,7 @@ add_fpga_target(
   BOARD qlf_k4n8-qlf_k4n8_umc22_board
   SOURCES counter.v
   INPUT_IO_FILE test.pcf
+  INPUT_SDC_FILE counter.sdc
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
 )
@@ -17,6 +19,7 @@ add_fpga_target(
   BOARD qlf_k4n8-qlf_k4n8_umc22_board
   SOURCES counter.v
   INPUT_IO_FILE test.pcf
+  INPUT_SDC_FILE counter.sdc
   EXPLICIT_ADD_FILE_TARGET
   )
 

--- a/quicklogic/qlf_k4n8/tests/counter/counter.sdc
+++ b/quicklogic/qlf_k4n8/tests/counter/counter.sdc
@@ -1,0 +1,1 @@
+create_clock -period 10.0 clk -waveform {0.000 5.000}

--- a/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
@@ -38,7 +38,8 @@ def absorb_buffer_luts(netlist, outputs=False):
 
             # Must not be driving any top-level outputs unless explicitly
             # allowed
-            if net_out in netlist.outputs and not outputs:
+            if (net_inp in netlist.inputs
+                    or net_out in netlist.outputs) and not outputs:
                 return False
 
             return True

--- a/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
@@ -8,7 +8,7 @@ import logging
 # =============================================================================
 
 
-def absorb_buffer_luts(netlist):
+def absorb_buffer_luts(netlist, outputs=False):
     """
     Performs downstream absorbtion of buffer LUTs. All buffer LUTs are absorbed
     except for those that drive top-level output ports not to change output
@@ -29,11 +29,16 @@ def absorb_buffer_luts(netlist):
         # A pass-through LUT
         if cell.type == "$lut" and cell.init == [0, 1]:
 
+            # Get input and output nets
+            assert INP_PORT in cell.ports, cell
+            net_inp = cell.ports[INP_PORT]
+
             assert OUT_PORT in cell.ports, cell
             net_out = cell.ports[OUT_PORT]
 
-            # Must not be driving any top-level outputs
-            if net_out in netlist.outputs:
+            # Must not be driving any top-level outputs unless explicitly
+            # allowed
+            if net_out in netlist.outputs and not outputs:
                 return False
 
             return True
@@ -58,18 +63,42 @@ def absorb_buffer_luts(netlist):
         assert OUT_PORT in cell.ports, cell
         net_out = cell.ports[OUT_PORT]
 
-        # Replace the output net in all cells with the input one
-        for c in netlist.cells.values():
-            for port, net in c.ports.items():
-                if net == net_out:
-                    c.ports[port] = net_inp
+        # Cannot be a buffer connecting an input to an output directly
+        if net_out in netlist.outputs and net_inp in netlist.inputs:
+            continue
 
-        # Update net map
-        for net in net_map:
-            if net_map[net] == net_out:
-                net_map[net] = net_inp
+        # This cell drives a top-level output directly. Change input nets and
+        # leave the output one
+        if net_out in netlist.outputs:
 
-        net_map[net_out] = net_inp
+            # Replace the output net in all cells with the input one
+            for c in netlist.cells.values():
+                for port, net in c.ports.items():
+                    if net == net_inp:
+                        c.ports[port] = net_out
+
+            # Update net map
+            for net in net_map:
+                if net_map[net] == net_inp:
+                    net_map[net] = net_out
+
+            net_map[net_inp] = net_out
+
+        # A regular buffer
+        else:
+
+            # Replace the output net in all cells with the input one
+            for c in netlist.cells.values():
+                for port, net in c.ports.items():
+                    if net == net_out:
+                        c.ports[port] = net_inp
+
+            # Update net map
+            for net in net_map:
+                if net_map[net] == net_out:
+                    net_map[net] = net_inp
+
+            net_map[net_out] = net_inp
 
         # Remove the cell
         del netlist.cells[cell.name]

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -1102,7 +1102,6 @@ def main():
     # Process netlist CLBs
     logging.info("Processing CLBs...")
 
-    removed_ios = set()
     leaf_block_names = {}
 
     route_through_net_ids = {}


### PR DESCRIPTION
This PR reworks the repacker to allow having top level IO ports in the patched netlist and eblif.

Top level IO ports are rather important to have in case some of the ports are used as clock sources. If these ports get deleted from the repacker, VPR will never know which one was a part of a clock net, therefore being unable to correctly read any SDC.

To allow VPR to correctly run, the absorption of LUT buffers has been disabled at the moment, as VPR was modifies the patched eblif, making it incompatible with the patched netlist. The disable of the LUT buffer absorption is a short term solution, and a proper re-work of the repacker needs to be done.

In addition, this PR is using changes in https://github.com/QuickLogic-Corp/qlfpga-symbiflow-plugins/pull/11, which will need to be properly handled in the patching scripts, instead of hardcoding them in the architecture.