### PR TITLE
Fix for LUT mapping #2

### DIFF
--- a/quicklogic/qlf_k4n8/utils/repacker/pb_type.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_type.py
@@ -97,7 +97,8 @@ class Port:
                 if i1 > i0:
                     indices = range(i0, i1 + 1)
                 elif i1 < i0:
-                    indices = range(i0, i1 - 1, -1)
+                    # Do not yield in reverse order when indices are reversed
+                    indices = range(i1, i0 + 1)
                 else:
                     indices = [i0]
 

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -706,7 +706,10 @@ def repack_netlist_cell(
         # Pad with 0s to match LUT width
         assert (1 << lut_width) >= len(init), (lut_width, init)
         pad_len = (1 << lut_width) - len(init)
-        init = init + "0" * pad_len
+        init = "0" * pad_len + init
+
+        # Reverse LUT bit order
+        init = init[::-1]
 
         repacked_cell.parameters["LUT"] = init
 
@@ -734,6 +737,9 @@ def repack_netlist_cell(
         if "IN2_IS_CIN" in cell.parameters:
             repacked_cell.parameters["MODE"] = cell.parameters["IN2_IS_CIN"]
             del repacked_cell.parameters["IN2_IS_CIN"]
+
+        # Reverse LUT bit order
+        repacked_cell.parameters["LUT"] = repacked_cell.parameters["LUT"][::-1]
 
     # If the rule contains mode bits then append the MODE parameter to the cell
     if rule.mode_bits:


### PR DESCRIPTION
 - Fixed interpretation of port mapping in repacking rules
 - Added bit reversal for LUT parameter when repacking `adder_lut4` cell.