### PR TITLE
Fix for repacker constraints

### DIFF
--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_netlist.py
@@ -169,6 +169,9 @@ def build_packed_netlist_from_pb_graph(clb_graph):
             # Next level
             parent = block
 
+    # Check if the CLB got created
+    assert clb_block is not None
+
     # Add open blocks.
     for node in clb_graph.nodes.values():
 


### PR DESCRIPTION
This PR fixes incorrect behavior of constrained nets in the repacker by not allowing to constrain an output net to an input port and vice-versa. It also adds a check whether all nets specified in the constraints file are present in the design.