### PR TITLE
Repacker constraints in CMake

### DIFF
--- a/quicklogic/qlf_k4n8/tests/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_custom_target(all_qlf_k4n8_tests_no_adder)
 add_custom_target(all_qlf_k4n8_tests_adder)
 
 add_subdirectory(counter_16bit)
+add_subdirectory(counter_4clk)
 
 add_dependencies(all_quicklogic_tests all_qlf_k4n8_tests_no_adder)
 add_dependencies(all_quicklogic_tests all_qlf_k4n8_tests_adder)

--- a/quicklogic/qlf_k4n8/tests/counter_4clk/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/counter_4clk/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_file_target(FILE counter_4clk.v SCANNER_TYPE verilog)
+add_file_target(FILE counter_4clk.sdc SCANNER_TYPE)
+add_file_target(FILE test.pcf)
+
+add_fpga_target(
+  NAME counter_4clk-umc22-no-adder
+  TOP top
+  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  SOURCES counter_4clk.v
+  INPUT_IO_FILE test.pcf
+  INPUT_SDC_FILE counter_4clk.sdc
+  EXPLICIT_ADD_FILE_TARGET
+  DEFINES SYNTH_OPTS=-no_adder
+  NET_PATCH_EXTRA_ARGS "--repacking-constraints ${CMAKE_CURRENT_SOURCE_DIR}/constraints.json"
+)
+
+add_fpga_target(
+  NAME counter_4clk-umc22-adder
+  TOP top
+  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  SOURCES counter_4clk.v
+  INPUT_IO_FILE test.pcf
+  INPUT_SDC_FILE counter_4clk.sdc
+  EXPLICIT_ADD_FILE_TARGET
+  NET_PATCH_EXTRA_ARGS "--repacking-constraints ${CMAKE_CURRENT_SOURCE_DIR}/constraints.json"
+)
+
+add_dependencies(all_qlf_k4n8_tests_no_adder counter_4clk-umc22-no-adder_bit)
+add_dependencies(all_qlf_k4n8_tests_adder    counter_4clk-umc22-adder_bit)

--- a/quicklogic/qlf_k4n8/tests/counter_4clk/constraints.json
+++ b/quicklogic/qlf_k4n8/tests/counter_4clk/constraints.json
@@ -1,0 +1,24 @@
+{
+  "repacking_constraints": [
+    {
+      "tile": "clb",
+      "pin": "clk[0]",
+      "net": "clk1"
+    },
+    {
+      "tile": "clb",
+      "pin": "clk[1]",
+      "net": "clk2"
+    },
+    {
+      "tile": "clb",
+      "pin": "clk[2]",
+      "net": "clk3"
+    },
+    {
+      "tile": "clb",
+      "pin": "clk[3]",
+      "net": "clk4"
+    }
+  ]
+}

--- a/quicklogic/qlf_k4n8/tests/counter_4clk/counter_4clk.sdc
+++ b/quicklogic/qlf_k4n8/tests/counter_4clk/counter_4clk.sdc
@@ -1,0 +1,4 @@
+create_clock -period 10.0 clk1 -waveform {0.000 5.000}
+create_clock -period 10.0 clk2 -waveform {0.000 5.000}
+create_clock -period 10.0 clk3 -waveform {0.000 5.000}
+create_clock -period 10.0 clk4 -waveform {0.000 5.000}

--- a/quicklogic/qlf_k4n8/tests/counter_4clk/counter_4clk.v
+++ b/quicklogic/qlf_k4n8/tests/counter_4clk/counter_4clk.v
@@ -1,0 +1,35 @@
+module top(
+    (* clkbuf_inhibit *)
+    input  wire       clk1,
+    (* clkbuf_inhibit *)
+    input  wire       clk2,
+    (* clkbuf_inhibit *)
+    input  wire       clk3,
+    (* clkbuf_inhibit *)
+    input  wire       clk4,
+    output wire [3:0] led
+);
+
+    reg [7:0] cnt1;
+    initial cnt1 <= 0;
+    always @(posedge clk1)
+        cnt1 <= cnt1 + 1;
+
+    reg [7:0] cnt2;
+    initial cnt2 <= 0;
+    always @(posedge clk2)
+        cnt2 <= cnt2 + 1;
+
+    reg [7:0] cnt3;
+    initial cnt3 <= 0;
+    always @(posedge clk3)
+        cnt3 <= cnt3 + 1;
+
+    reg [7:0] cnt4;
+    initial cnt4 <= 0;
+    always @(posedge clk4)
+        cnt4 <= cnt4 + 1;
+
+    assign led = {cnt4[7], cnt3[7], cnt2[7], cnt1[7]};
+
+endmodule

--- a/quicklogic/qlf_k4n8/tests/counter_4clk/test.pcf
+++ b/quicklogic/qlf_k4n8/tests/counter_4clk/test.pcf
@@ -1,0 +1,4 @@
+set_io led[0] user_OUT_B[30]
+set_io led[1] user_OUT_T[11]
+set_io led[2] user_OUT_B[74]
+set_io led[3] user_OUT_R[35]


### PR DESCRIPTION
This PR allows to specify repacking constraints for each design in the CMake build system. It also adds an example of how it should be done.