### PR TITLE
Fixing up post-layout Verilog netlist from VPR

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -2188,8 +2188,8 @@ function(ADD_FPGA_TARGET)
     COMMAND ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/vpr_stdout.log
         ${OUT_LOCAL}/analysis.log
     COMMAND ${PYTHON3} ${FIXUP_POST_SYNTHESIS}
-        ${OUT_POST_SYNTHESIS_V}
-        ${OUT_POST_SYNTHESIS_V}
+        -i ${OUT_POST_SYNTHESIS_V}
+        -o ${OUT_POST_SYNTHESIS_V}
     WORKING_DIRECTORY ${OUT_LOCAL}
     )
   add_custom_target(${NAME}_analysis DEPENDS ${OUT_ANALYSIS})

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -2176,15 +2176,20 @@ function(ADD_FPGA_TARGET)
 
   # Generate analysis.
   #-------------------------------------------------------------------------
+  set(FIXUP_POST_SYNTHESIS ${symbiflow-arch-defs_SOURCE_DIR}/utils/vpr_fixup_post_synth.py)
+
   set(OUT_ANALYSIS ${OUT_LOCAL}/analysis.log)
-  set(OUT_POST_SYNTHESIS_V ${OUT_LOCAL}/top_post_synthesis.v)
-  set(OUT_POST_SYNTHESIS_BLIF ${OUT_LOCAL}/top_post_synthesis.blif)
+  set(OUT_POST_SYNTHESIS_V ${OUT_LOCAL}/${TOP}_post_synthesis.v)
+  set(OUT_POST_SYNTHESIS_BLIF ${OUT_LOCAL}/${TOP}_post_synthesis.blif)
   add_custom_command(
     OUTPUT ${OUT_ANALYSIS} ${OUT_POST_SYNTHESIS_V} ${OUT_POST_SYNTHESIS_BLIF}
-    DEPENDS ${OUT_ROUTE} ${VPR_DEPS}
+    DEPENDS ${OUT_ROUTE} ${VPR_DEPS} ${PYTHON3} ${FIXUP_POST_SYNTHESIS}
     COMMAND ${VPR_CMD} ${OUT_EBLIF} ${VPR_ARGS} --analysis --gen_post_synthesis_netlist on
     COMMAND ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/vpr_stdout.log
         ${OUT_LOCAL}/analysis.log
+    COMMAND ${PYTHON3} ${FIXUP_POST_SYNTHESIS}
+        ${OUT_POST_SYNTHESIS_V}
+        ${OUT_POST_SYNTHESIS_V}
     WORKING_DIRECTORY ${OUT_LOCAL}
     )
   add_custom_target(${NAME}_analysis DEPENDS ${OUT_ANALYSIS})

--- a/quicklogic/common/cmake/quicklogic_install.cmake
+++ b/quicklogic/common/cmake/quicklogic_install.cmake
@@ -105,6 +105,10 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
           DESTINATION bin/python/lib
           PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
 
+  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/vpr_fixup_post_synth.py
+          DESTINATION bin/python
+          PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
+
   # install the repacker
   set(REPACKER_FILES
     arch_xml_utils.py

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -489,7 +489,7 @@ fi
 	cd \${BUILDDIR} && symbiflow_route -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.post_v: \${BUILDDIR}/\${TOP_FINAL}.route\n\
-	cd \${BUILDDIR} && symbiflow_analysis -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_analysis -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -t \${TOP} >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.fasm: \${BUILDDIR}/\${TOP_FINAL}.route\n\
 	cd \${BUILDDIR} && symbiflow_write_fasm -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} >> $LOG_FILE 2>&1\n\

--- a/quicklogic/common/toolchain_wrappers/symbiflow_analysis
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_analysis
@@ -9,8 +9,13 @@ source ${VPRPATH}/vpr_common
 
 parse_args $@
 
+FIXUP_POST_SYNTHESIS=`realpath ${MYPATH}/python/vpr_fixup_post_synth.py`
+
 export OUT_NOISY_WARNINGS=noisy_warnings-${DEVICE}_analysis.log
 
 run_vpr --analysis --gen_post_synthesis_netlist on
-
 mv vpr_stdout.log analysis.log
+
+python3 ${FIXUP_POST_SYNTHESIS} \
+    ${TOP}_post_synthesis.v \
+    ${TOP}_post_synthesis.v

--- a/quicklogic/common/toolchain_wrappers/symbiflow_analysis
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_analysis
@@ -17,5 +17,5 @@ run_vpr --analysis --gen_post_synthesis_netlist on
 mv vpr_stdout.log analysis.log
 
 python3 ${FIXUP_POST_SYNTHESIS} \
-    ${TOP}_post_synthesis.v \
-    ${TOP}_post_synthesis.v
+    -i ${TOP}_post_synthesis.v \
+    -o ${TOP}_post_synthesis.v

--- a/quicklogic/common/toolchain_wrappers/vpr_common
+++ b/quicklogic/common/toolchain_wrappers/vpr_common
@@ -1,8 +1,8 @@
 #!/bin/bash
 function parse_args {
 
-     OPTS=d:f:e:p:n:P:j:s:
-     LONGOPTS=device:,eblif:,pcf:,net:,part:,json:,sdc:
+     OPTS=d:f:e:p:n:P:j:s:t:
+     LONGOPTS=device:,eblif:,pcf:,net:,part:,json:,sdc:,top:
 
      PARSED_OPTS=`getopt --options=${OPTS} --longoptions=${LONGOPTS} --name $0 -- $@`
      eval set -- ${PARSED_OPTS}
@@ -16,6 +16,7 @@ function parse_args {
      NET=""
      SDC=""
      JSON=""
+     TOP="top"
 
      while true; do
           case "$1" in
@@ -51,6 +52,10 @@ function parse_args {
                     SDC=$2
                     shift 2
                     ;;
+               -t|--top)
+                    TOP=$2
+                    shift 2
+                    ;;
                --)
                     break
                     ;;
@@ -82,6 +87,7 @@ function parse_args {
      if [[ "$DEVICE" == "qlf_k4n8_qlf_k4n8" ]]; then
 	     DEVICE_1="qlf_k4n8-qlf_k4n8_umc22"
      fi
+     export TOP=$TOP
 
      export ARCH_DIR=`realpath ${MYPATH}/../share/symbiflow/arch/${DEVICE_1}_${DEVICE_1}`
      export ARCH_DEF=${ARCH_DIR}/arch_${DEVICE_1}_${DEVICE_1}.xml

--- a/utils/vpr_fixup_post_synth.py
+++ b/utils/vpr_fixup_post_synth.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+A simple script that fixes up post-pnr verilog files from VPR.
+
+It appends a correct prefix for  each occurrence of a binary string in round
+brackets. For example "(010101)" is converted into "(6'b010101)".
+
+One shortcoming of the script is that it may treat a decimal value of 10, 100
+etc. as binary. Fortunately decimal literals haven't been observed to appear
+in Verilog files written by VPR.
+"""
+import argparse
+import re
+
+# =============================================================================
+
+
+def main():
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument("i", type=str, help="Input Verilog file")
+    parser.add_argument("o", type=str, help="Output Verilog file")
+
+    args = parser.parse_args()
+
+    # Read the input verilog file
+    with open(args.i, "r") as fp:
+        code = fp.read()
+
+    def sub_func(match):
+        assert match is not None
+        value = match.group("val")
+
+        # Collapse separators "_"
+        value = value.replace("_", "")
+
+        # Add prefix, format the final string
+        lnt = len(value)
+        return "({}'b{})".format(lnt, value)
+
+    code = re.sub(r"\(\s*(?P<val>[01_]+)\s*\)", sub_func, code)
+
+    # Write the output verilog file
+    with open(args.o, "w") as fp:
+        fp.write(code)
+
+
+# =============================================================================
+
+if __name__ == "__main__":
+    main()

--- a/utils/vpr_fixup_post_synth.py
+++ b/utils/vpr_fixup_post_synth.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 """
-A simple script that fixes up post-pnr verilog files from VPR.
+A simple script that fixes up post-pnr verilog files from VPR:
 
-It appends a correct prefix for  each occurrence of a binary string in round
-brackets. For example "(010101)" is converted into "(6'b010101)".
+ - Removes incorrect constants "1'b0" connected to unconnected cell port,
+
+ - Disconnects all unconnected outputs from the "DummyOut" net,
+
+ - appends a correct prefix for  each occurrence of a binary string in round
+   brackets. For example "(010101)" is converted into "(6'b010101)".
 
 One shortcoming of the script is that it may treat a decimal value of 10, 100
 etc. as binary. Fortunately decimal literals haven't been observed to appear
@@ -36,6 +40,32 @@ def main():
     with open(args.i, "r") as fp:
         code = fp.read()
 
+    # Remove connection to 1'b0 from all ports. Do this before fixing up
+    # binary string prefixes so binary parameters won't be affected
+    code = re.sub(
+        r"\.(?P<port>\w+)\s*\(\s*1'b0\s*\)", r".\g<port>(1'bZ)", code
+    )
+
+    # Remove connections to the "DummyOut" net
+    code = re.sub(
+        r"\.(?P<port>\w+)\s*\(\s*DummyOut\s*\)", r".\g<port>()", code
+    )
+
+    # Fixup multi-bit port connections
+    def sub_func_1(match):
+        port = match.group("port")
+        conn = match.group("conn")
+
+        conn = re.sub(r"1'b0", "1'bZ", conn)
+        conn = re.sub(r"DummyOut", "", conn)
+
+        return ".{}({{{}}})".format(port, conn)
+
+    code = re.sub(
+        r"\.(?P<port>\w+)\s*\(\s*{(?P<conn>[^}]*)}\s*\)", sub_func_1, code
+    )
+
+    # Prepend binary literal prefixes
     def sub_func(match):
         assert match is not None
         value = match.group("val")

--- a/utils/vpr_fixup_post_synth.py
+++ b/utils/vpr_fixup_post_synth.py
@@ -23,8 +23,12 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
-    parser.add_argument("i", type=str, help="Input Verilog file")
-    parser.add_argument("o", type=str, help="Output Verilog file")
+    parser.add_argument(
+        "-i", type=str, required=True, help="Input Verilog file"
+    )
+    parser.add_argument(
+        "-o", type=str, required=True, help="Output Verilog file"
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR fixes post layout netlists written by VPR:
 - Adds proper prefixes to binary literals (eg. "010101" becomes "6'b010101")
 - Removes `1'b0` constants incorrectly assigned to unconnected input ports
 - Removes connections to the `DummyOut` net present at every unconnected output.

The fix is added both to the CMake and the installed toolchain flow. The solution will work for now but the ultimate correct way of solving it is through modifying VPR (see https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1662 and https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1721).

This PR should fix the issue: https://github.com/lnsharma/symbiflow-arch-defs/issues/109