### PR TITLE
qlf_4kn8: Add different corners

### DIFF
--- a/.github/ci/common.sh
+++ b/.github/ci/common.sh
@@ -50,20 +50,23 @@ fi
 function make_target() {
   target=$1
 
-  if [ ! -v MAKE_JOBS ]; then
-    export MAKE_JOBS=$(nproc)
-    echo "Setting MAKE_JOBS to $MAKE_JOBS"
-  fi;
+  if [ -z ${MAKE_JOBS} ]; then
+    JOBS=$(nproc)
+    echo "Setting JOBS to ${JOBS}"
+  else
+	JOBS=${MAKE_JOBS}
+    echo "JOBS set to ${JOBS}"
+  fi
 
-  export VPR_NUM_WORKERS=${MAKE_JOBS}
+  export VPR_NUM_WORKERS=${JOBS}
 
   start_section "symbiflow.$target" "$2"
   make_status=0
-  make -k -j${MAKE_JOBS} $target || make_status=$?
+  make -k -j${JOBS} $target || make_status=$?
   end_section "symbiflow.$target"
 
   # When the build fails, produce the failure output in a clear way
-  if [ ${MAKE_JOBS} -ne 1 -a $make_status -ne 0 ]; then
+  if [ ${JOBS} -ne 1 -a $make_status -ne 0 ]; then
     start_section "symbiflow.failure" "${RED}Build failure output..${NC}"
     make -j1 $target
     end_section "symbiflow.failure"

--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -30,7 +30,7 @@ start_section "symbiflow.build_all_rrgraph_xmls" "Build all rrgraph XMLs."
 make all_rrgraph_xmls
 end_section "symbiflow.build_all_rrgraph_xmls"
 
-make_target all_route_tests "Complete all routing tests"
+MAKE_JOBS=1 make_target all_route_tests "Complete all routing tests"
 
 echo "Suppressing some xml linting, as the 5k/8k parts cannot be built on GH actions."
 make_target all_xml_lint "Complete all xmllint"

--- a/quicklogic/common/cmake/quicklogic_board.cmake
+++ b/quicklogic/common/cmake/quicklogic_board.cmake
@@ -41,13 +41,13 @@ function(ADD_QUICKLOGIC_BOARD)
     get_target_property_required(VPR_DB_FILE ${DEVICE_TYPE} VPR_DB_FILE)
     get_file_location(VPR_DB_FILE_LOC ${VPR_DB_FILE})
     get_file_target(VPR_DB_TARGET ${VPR_DB_FILE})
-  
+
     # Generate clock pad map CSV file
     set(CREATE_CLKMAP_CSV ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/common/utils/create_clkmap_csv.py)
     set(CLKMAP_CSV ${BOARD}_clkmap.csv)
     set(CLKMAP_CSV_DEPS ${PYTHON3} ${PYTHON3_TARGET} ${CREATE_CLKMAP_CSV})
     append_file_dependency(CLKMAP_CSV_DEPS ${VPR_DB_FILE})
-  
+
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${CLKMAP_CSV}
       COMMAND ${PYTHON3} ${CREATE_CLKMAP_CSV}
@@ -55,19 +55,19 @@ function(ADD_QUICKLOGIC_BOARD)
         --db ${VPR_DB_FILE_LOC}
       DEPENDS ${CLKMAP_CSV_DEPS}
     )
-  
+
     add_file_target(FILE ${CLKMAP_CSV} GENERATED)
-  
+
     # Generate pinmap CSV file
     set(CREATE_PINMAP_CSV ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/common/utils/create_pinmap_csv.py)
     set(PINMAP_CSV ${BOARD}_pinmap.csv)
     set(PINMAP_CSV_DEPS ${PYTHON3} ${PYTHON3_TARGET} ${CREATE_PINMAP_CSV})
     append_file_dependency(PINMAP_CSV_DEPS ${VPR_DB_FILE})
-  
+
     # Make the pinmap depend on clkmap. This way it is build without the need for
     # adding the dependency elsewhere.
     append_file_dependency(PINMAP_CSV_DEPS ${CLKMAP_CSV})
-  
+
     # TODO: Use the PACKAGE in the pinmap CSV generation.
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_CSV}
@@ -77,9 +77,9 @@ function(ADD_QUICKLOGIC_BOARD)
         --db ${VPR_DB_FILE_LOC}
       DEPENDS ${PINMAP_CSV_DEPS}
     )
-  
+
     add_file_target(FILE ${PINMAP_CSV} GENERATED)
-  
+
     # Set the board properties
     set_target_properties(
       ${BOARD}
@@ -89,7 +89,7 @@ function(ADD_QUICKLOGIC_BOARD)
         CLKMAP
         ${CMAKE_CURRENT_SOURCE_DIR}/${CLKMAP_CSV}
     )
-  
+
     set_target_properties(
       dummy_${ARCH}_${DEVICE}_${PACKAGE}
       PROPERTIES
@@ -145,11 +145,11 @@ function(ADD_QUICKLOGIC_BOARD)
     set(PINMAP_CSV ${BOARD}_pinmap.csv)
     set(PINMAP_CSV_DEPS ${PYTHON3} ${PYTHON3_TARGET} ${CREATE_PINMAP_CSV} ${TECHFILE})
     append_file_dependency(PINMAP_CSV_DEPS ${RR_GRAPH_FILE})
-  
+
     # Make the pinmap depend on clkmap. This way it is build without the need for
     # adding the dependency elsewhere.
     append_file_dependency(PINMAP_CSV_DEPS ${CLKMAP_CSV})
-  
+
     # TODO: Use the PACKAGE in the pinmap CSV generation.
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_CSV}
@@ -160,7 +160,7 @@ function(ADD_QUICKLOGIC_BOARD)
         --vpr-grid-map ${VPR_GRID_MAP_LOCATION}
       DEPENDS ${PINMAP_CSV_DEPS}
     )
-  
+
     add_file_target(FILE ${PINMAP_CSV} GENERATED)
 
     # Set the board properties
@@ -172,7 +172,7 @@ function(ADD_QUICKLOGIC_BOARD)
         CLKMAP
         ${CMAKE_CURRENT_SOURCE_DIR}/${CLKMAP_CSV}
     )
-  
+
     set_target_properties(
       dummy_${ARCH}_${DEVICE}_${PACKAGE}
       PROPERTIES
@@ -193,33 +193,41 @@ function(ADD_QUICKLOGIC_BOARD)
     set(PINMAP_CSV ${PINMAP})
 
     # Copy the pinmap XML
-    add_custom_command(
-      OUTPUT
-        ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_XML}
-      COMMAND
-        ${CMAKE_COMMAND} -E copy
-          ${CMAKE_CURRENT_SOURCE_DIR}/devices/umc22/${PINMAP_XML}
+    get_file_target(PINMAP_XML_TARGET ${PINMAP_XML})
+
+    if(NOT TARGET ${PINMAP_XML_TARGET})
+      add_custom_command(
+        OUTPUT
           ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_XML}
-    )
-    add_file_target(FILE ${PINMAP_XML} GENERATED)
+        COMMAND
+          ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_SOURCE_DIR}/devices/umc22/${PINMAP_XML}
+            ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_XML}
+      )
+      add_file_target(FILE ${PINMAP_XML} GENERATED)
+    endif()
 
     # Make the pinmap CSV depend on pinmap XML. This way the file will be
     # created  without the need for adding the dependency elsewhere.
     set(PINMAP_CSV_DEPS)
     append_file_dependency(PINMAP_CSV_DEPS ${PINMAP_XML})
 
-    # Copy the pinmap CSV
-    add_custom_command(
-      OUTPUT
-        ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_CSV}
-      COMMAND
-        ${CMAKE_COMMAND} -E copy
-          ${CMAKE_CURRENT_SOURCE_DIR}/devices/umc22/${PINMAP_CSV}
+    get_file_target(PINMAP_CSV_TARGET ${PINMAP_CSV})
+
+    if(NOT TARGET ${PINMAP_CSV_TARGET})
+      # Copy the pinmap CSV
+      add_custom_command(
+        OUTPUT
           ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_CSV}
-      DEPENDS
-        ${PINMAP_CSV_DEPS}
-    )
-    add_file_target(FILE ${PINMAP_CSV} GENERATED)
+        COMMAND
+          ${CMAKE_COMMAND} -E copy
+            ${CMAKE_CURRENT_SOURCE_DIR}/devices/umc22/${PINMAP_CSV}
+            ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_CSV}
+        DEPENDS
+          ${PINMAP_CSV_DEPS}
+      )
+      add_file_target(FILE ${PINMAP_CSV} GENERATED)
+    endif()
 
 
     # Set the board properties

--- a/quicklogic/common/cmake/quicklogic_install.cmake
+++ b/quicklogic/common/cmake/quicklogic_install.cmake
@@ -84,7 +84,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/common/utils/pinmap_parse.py
           DESTINATION bin/python
           PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
-  
+
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/utils/create_lib.py
 	  DESTINATION bin/python
 	  PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
@@ -139,7 +139,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
   # install lib files
   install(DIRECTORY ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/devices/umc22/
 	  DESTINATION "share/symbiflow/arch/${FAMILY}-${FAMILY}_umc22_${FAMILY}-${FAMILY}_umc22/lib"
-	  FILES_MATCHING 
+	  FILES_MATCHING
 	  PATTERN "*.txt"
 	  PATTERN "*.json"
 	  PATTERN "*.xml")

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -14,7 +14,7 @@ if [ ! -n $1 ]; then
 echo "Please enter a valid command: Refer help ql_symbiflow --help"
 exit 0
 elif [[ $1 == "-synth" || $1 == "-compile" ]]; then
-echo -e "----------------- \n" 
+echo -e "----------------- \n"
 elif [[ $1 == "-h"  ||  $1 == "--help" ]];then
 echo -e "\nBelow are the supported commands: \n\
  To synthesize and dump a eblif file:\n\
@@ -44,6 +44,8 @@ OUT=()
 ROUTE_FLAG0=""
 MAX_CRITICALITY="0.0"
 JSON=""
+PNR_CORNER="slow"
+ANALYSIS_CORNER="slow"
 
 VERILOGLIST=0
 PCFNAME=0
@@ -56,11 +58,13 @@ SDCNAME=0
 OUTNAME=0
 ROUTE_NAME0=0
 JSON_NAME=0
+PNR_CORNER_NAME=0
+ANALYSIS_CORNER_NAME=0
 
 for arg_v in $@; do
 	echo $arg_v
 	case "$arg_v" in
-                -src|--source)
+		-src|--source)
 			VERILOGLIST=0
 			PCFNAME=0
 			TOPNAME=0
@@ -72,6 +76,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-t|--top)
 			VERILOGLIST=0
@@ -85,6 +91,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-v|--verilog)
 			VERILOGLIST=1
@@ -98,6 +106,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-d|--device)
 			VERILOGLIST=0
@@ -111,6 +121,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-h|--help)
 			VERILOGLIST=0
@@ -124,6 +136,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-p|--pcf)
 			VERILOGLIST=0
@@ -137,6 +151,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-P|--part)
 			VERILOGLIST=0
@@ -150,6 +166,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-j|--json)
 			VERILOGLIST=0
@@ -158,11 +176,13 @@ for arg_v in $@; do
 			SOURCEDIR=0
 			HELPNAME=0
 			DEVICENAME=0
-			PARTNAME=1
+			PARTNAME=0
 			SDCNAME=0
 			ROUTE_NAME0=0
 			OUTNAME=0
 			JSON_NAME=1
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-s|--sdc)
 			VERILOGLIST=0
@@ -176,6 +196,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-r|--route_type)
 			VERILOGLIST=0
@@ -189,6 +211,38 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=1
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
+			;;
+		-pnr_corner)
+			VERILOGLIST=0
+			PCFNAME=0
+			TOPNAME=0
+			SOURCEDIR=0
+			HELPNAME=0
+			DEVICENAME=0
+			PARTNAME=0
+			SDCNAME=0
+			OUTNAME=0
+			ROUTE_NAME0=0
+			JSON_NAME=0
+			PNR_CORNER_NAME=1
+			ANALYSIS_CORNER_NAME=0
+			;;
+		-analysis_corner)
+			VERILOGLIST=0
+			PCFNAME=0
+			TOPNAME=0
+			SOURCEDIR=0
+			HELPNAME=0
+			DEVICENAME=0
+			PARTNAME=0
+			SDCNAME=0
+			OUTNAME=0
+			ROUTE_NAME0=0
+			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=1
 			;;
 		-dump)
 			VERILOGLIST=0
@@ -202,6 +256,8 @@ for arg_v in $@; do
 			OUTNAME=1
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 		-synth|-compile)
 			VERILOGLIST=0
@@ -215,6 +271,8 @@ for arg_v in $@; do
 			OUTNAME=0
 			ROUTE_NAME0=0
 			JSON_NAME=0
+			PNR_CORNER_NAME=0
+			ANALYSIS_CORNER_NAME=0
 			;;
 
 		*)
@@ -223,7 +281,7 @@ for arg_v in $@; do
 			elif [ $VERILOGLIST -eq 1 ]; then
 				VERILOG_FILES+="$arg_v "
 			elif [ $HELPNAME -eq 1 ]; then
-				echo "" 
+				echo ""
 			elif [ $TOPNAME -eq 1 ]; then
 				TOP=$arg_v
 			elif [ $DEVICENAME -eq 1 ]; then
@@ -251,6 +309,12 @@ for arg_v in $@; do
 				OUT+="$arg_v "
 			elif [ $PARTNAME -eq 1 ]; then
 				PART="${arg_v}"
+			elif [ $PNR_CORNER_NAME -eq 1 ]; then
+				PNR_CORNER="${arg_v}"
+			elif [ $ANALYSIS_CORNER_NAME -eq 1 ]; then
+				ANALYSIS_CORNER="${arg_v}"
+			elif [ $PARTNAME -eq 1 ]; then
+				PART="${arg_v}"
 			else
 				echo "Refer help for more details: ql_symbiflow -h "
                                 exit 1
@@ -270,15 +334,15 @@ else
     elif [ $SOURCE == "." ];then
     SOURCE=$PWD
     elif [ ! -d "$SOURCE" ];then
-    echo "Directory path $SOURCE DOES NOT exists. Please add absolute path" 
+    echo "Directory path $SOURCE DOES NOT exists. Please add absolute path"
     exit 1
     fi
 
 if [[ $1 == "-h"  ||  $1 == "--help" ]];then
 exit 0
 else
-if [ -f $SOURCE/v_list_tmp ];then 
-rm -f $SOURCE/v_list_tmp 
+if [ -f $SOURCE/v_list_tmp ];then
+rm -f $SOURCE/v_list_tmp
 fi
 echo "$VERILOG_FILES" >${SOURCE}/v_list
 fi
@@ -312,7 +376,7 @@ if [[ $1 == "-compile" || $1 == "-post_verilog" ]]; then
   if [ -z "$DEVICE" ]; then
     echo "DEVICE name is missing. Refer -h/--help"
     exit 1
-  elif ! [[ "$DEVICE" =~ ^(qlf_k4n8_qlf_k4n8)$ ]]; then 
+  elif ! [[ "$DEVICE" =~ ^(qlf_k4n8_qlf_k4n8)$ ]]; then
 	  echo "Invalid Device name, supported qlf_k4n8"
     exit 1
   fi
@@ -325,16 +389,16 @@ if [[ $1 == "-compile" || $1 == "-post_verilog" ]]; then
 	   if [ -n "$PCF" ];then
 	     echo "Error: pcf file cannot be used without declaring PINMAP CSV file"
              exit 1
-           fi	     
+           fi
     fi
   fi
     if [ -z "$ROUTE_FLAG0" ]; then
       MAX_CRITICALITY="0.0"
-    elif ! [[ "$ROUTE_FLAG0" =~ ^(timing|congestion)$ ]]; then 
+    elif ! [[ "$ROUTE_FLAG0" =~ ^(timing|congestion)$ ]]; then
      echo "Invalid option name, supported timing/congestion"
          exit 1
      else
-	if [ "$ROUTE_FLAG0" == "congestion" ]; then 
+	if [ "$ROUTE_FLAG0" == "congestion" ]; then
          MAX_CRITICALITY="0.99"
 	else
 	MAX_CRITICALITY="0.0"
@@ -353,16 +417,16 @@ OUT_ARR=($OUT)
 fi
 
 for item in $VERILOG_FILES;
-do 
+do
 if ! [ -f $SOURCE/$item ]; then
  echo "$item: verilog file does not exists at : $SOURCE"
  exit 1
-elif [[ $item =~ ^/ ]]; then 
+elif [[ $item =~ ^/ ]]; then
 	echo "$item \\" >>$SOURCE/v_list_tmp
-else 
+else
 	echo "\${current_dir}/$item \\" >>$SOURCE/v_list_tmp
 fi
-done 
+done
 
 if [ -f "$SOURCE/v_list_tmp" ]; then
     truncate -s-2 "$SOURCE/v_list_tmp"
@@ -390,9 +454,9 @@ export PINMAP_FILE=$PINMAPCSV
 export MAX_CRITICALITY=$MAX_CRITICALITY
 ##### Create Makefile #####
 
-if [[ $SOURCE =~ ^/ ]]; then 
+if [[ $SOURCE =~ ^/ ]]; then
 	CURR_DIR="${SOURCE}"
-else 
+else
 	CURR_DIR="${PWD}/${SOURCE}"
 fi
 
@@ -400,7 +464,7 @@ if [ -n "$PART" ]; then
     if [[ -f $SOURCE/$PART ]];then
 	CSV_PATH=`realpath $SOURCE/$PART`
     elif [[ -f $PART ]];then
-        CSV_PATH=`realpath $PART` 
+        CSV_PATH=`realpath $PART`
     else
       echo "invalid csv file/path"
       exit 1
@@ -442,7 +506,7 @@ else
    	 SDC_MAKE="\${current_dir}/build/${TOP}_dummy.sdc"
 fi
 
-echo -e ".PHONY:\${BUILDDIR}\n 
+echo -e ".PHONY:\${BUILDDIR}\n
 current_dir := $CURR_DIR\n\
 TOP := $TOP\n\
 JSON := $JSON\n\
@@ -451,6 +515,8 @@ VERILOG := $VERILOG_LIST \n\
 PARTNAME := $PART\n\
 DEVICE  := $DEVICE\n\
 FAMILY := $FAMILY\n\
+ANALYSIS_CORNER := $PNR_CORNER\n\
+PNR_CORNER := $ANALYSIS_CORNER\n\
 PCF := $PCF_MAKE\n\
 SDC := $SDC_MAKE\n\
 BUILDDIR := build\n\n\
@@ -464,35 +530,35 @@ all: \${BUILDDIR}/\${TOP}.bit\n\
 	cd \${BUILDDIR} && symbiflow_synth -t \${TOP} -v \${VERILOG} -f \${FAMILY} -d \${DEVICE} -p \${PCF} > $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.net: \${BUILDDIR}/\${TOP}.eblif\n\
-	cd \${BUILDDIR} && symbiflow_pack -e \${TOP}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_pack -e \${TOP}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.place: \${BUILDDIR}/\${TOP}.net \${PCF}\n\
-	cd \${BUILDDIR} && symbiflow_place -e \${TOP}.eblif -f \${FAMILY} -d \${DEVICE} -p \${PCF} -n \${TOP}.net -P \${PARTNAME} -s \${SDC} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_place -e \${TOP}.eblif -f \${FAMILY} -d \${DEVICE} -p \${PCF} -n \${TOP}.net -P \${PARTNAME} -s \${SDC} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\
 " >$MAKE_FILE
 
 if [ "$TOP" != "$TOP_FINAL" ]; then
 	if [ -z "$JSON" ];then
     echo -e "\
 \${BUILDDIR}/\${TOP_FINAL}.place: \${BUILDDIR}/\${TOP}.eblif \${BUILDDIR}/\${TOP}.net \${BUILDDIR}/\${TOP}.place\n\
-	cd \${BUILDDIR} && symbiflow_repack -e \${TOP}.eblif -n \${TOP}.net -f \${FAMILY} -d \${DEVICE} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_repack -e \${TOP}.eblif -n \${TOP}.net -f \${FAMILY} -d \${DEVICE} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\
     " >>$MAKE_FILE
       else
     echo -e "\
 \${BUILDDIR}/\${TOP_FINAL}.place: \${BUILDDIR}/\${TOP}.eblif \${BUILDDIR}/\${TOP}.net \${BUILDDIR}/\${TOP}.place\n\
-	cd \${BUILDDIR} && symbiflow_repack -e \${TOP}.eblif -n \${TOP}.net -f \${FAMILY} -d \${DEVICE} -j \${JSON} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_repack -e \${TOP}.eblif -n \${TOP}.net -f \${FAMILY} -d \${DEVICE} -j \${JSON} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\
     " >>$MAKE_FILE
        fi
 fi
 
     echo -e "\
 \${BUILDDIR}/\${TOP_FINAL}.route: \${BUILDDIR}/\${TOP_FINAL}.place\n\
-	cd \${BUILDDIR} && symbiflow_route -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_route -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.post_v: \${BUILDDIR}/\${TOP_FINAL}.route\n\
-	cd \${BUILDDIR} && symbiflow_analysis -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -t \${TOP} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_analysis -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${ANALYSIS_CORNER} >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.fasm: \${BUILDDIR}/\${TOP_FINAL}.route\n\
-	cd \${BUILDDIR} && symbiflow_write_fasm -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_write_fasm -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.bit: \${BUILDDIR}/\${TOP}.fasm\n\
 	cd \${BUILDDIR} && symbiflow_generate_bitstream -d \${FAMILY} -f \${TOP}.fasm -r 4byte -b \${TOP}.bit >> $LOG_FILE 2>&1\n\
@@ -511,11 +577,11 @@ clean:\n\
 " >>$MAKE_FILE
 
 #### Remove temporary files #####
-rm -f $SOURCE/f_list_temp $SOURCE/v_list_tmp $SOURCE/v_list 
+rm -f $SOURCE/f_list_temp $SOURCE/v_list_tmp $SOURCE/v_list
 
 ##### Make file Targets #####
 if [ $1 == "-synth" ]; then
-  echo -e "Performing Synthesis " 
+  echo -e "Performing Synthesis "
   cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.eblif || exit
 elif [[ ! -z "$OUT" && $1 == "-compile" ]];then
 	if [[ " ${OUT_ARR[@]} " =~ " post_verilog " ]];then

--- a/quicklogic/common/toolchain_wrappers/symbiflow_analysis
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_analysis
@@ -13,7 +13,8 @@ FIXUP_POST_SYNTHESIS=`realpath ${MYPATH}/python/vpr_fixup_post_synth.py`
 
 export OUT_NOISY_WARNINGS=noisy_warnings-${DEVICE}_analysis.log
 
-run_vpr --analysis --gen_post_synthesis_netlist on
+run_vpr --analysis --gen_post_synthesis_netlist on --verify_file_digests off
+
 mv vpr_stdout.log analysis.log
 
 python3 ${FIXUP_POST_SYNTHESIS} \

--- a/quicklogic/common/toolchain_wrappers/symbiflow_generate_constraints
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_generate_constraints
@@ -10,9 +10,10 @@ NET=$3
 PART=$4
 DEVICE=$5
 ARCH_DEF=$6
+CORNER=$7
 
 if [[ "$DEVICE" =~ ^(qlf_k4n8_qlf_k4n8)$ ]];then
-	DEVICE_1="qlf_k4n8-qlf_k4n8_umc22"
+	DEVICE_1="qlf_k4n8-qlf_k4n8_umc22_$CORNER"
 	PINMAPXML="pinmap_qlf_k4n8_umc22.xml"
 else
     DEVICE_1=${DEVICE}

--- a/quicklogic/common/toolchain_wrappers/symbiflow_place
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_place
@@ -25,7 +25,7 @@ PROJECT=$(basename -- "$EBLIF")
 # Generate IO constraints
 if [ -s $PCF ]; then
     echo "Generating constraints ..."
-    symbiflow_generate_constraints $PCF $EBLIF $NET $PART $DEVICE $ARCH_DEF
+    symbiflow_generate_constraints $PCF $EBLIF $NET $PART $DEVICE $ARCH_DEF $CORNER
 
     IOPLACE_FILE="${PROJECT%.*}_io.place"
     PLACE_FILE="${PROJECT%.*}_constraints.place"

--- a/quicklogic/common/toolchain_wrappers/symbiflow_repack
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_repack
@@ -14,29 +14,20 @@ REPACK=`realpath ${MYPATH}/python/repacker/repack.py`
 DESIGN=${EBLIF/.eblif/}
 RULES=${ARCH_DIR}/${DEVICE_1}.repacking_rules.json
 
-if [ -z "${JSON}" ];then
-python3 ${REPACK} \
-  --vpr-arch ${ARCH_DEF} \
-  --repacking-rules ${RULES} \
-  --eblif-in ${DESIGN}.eblif \
-  --net-in ${DESIGN}.net \
-  --place-in ${DESIGN}.place \
-  --eblif-out ${DESIGN}.repacked.eblif \
-  --net-out ${DESIGN}.repacked.net \
-  --place-out ${DESIGN}.repacked.place \
-  --absorb_buffer_luts on \
-  >repack.log 2>&1
-else	
-python3 ${REPACK} \
-  --vpr-arch ${ARCH_DEF} \
-  --repacking-rules ${RULES} \
-  --repacking-constraints ${JSON} \
-  --eblif-in ${DESIGN}.eblif \
-  --net-in ${DESIGN}.net \
-  --place-in ${DESIGN}.place \
-  --eblif-out ${DESIGN}.repacked.eblif \
-  --net-out ${DESIGN}.repacked.net \
-  --place-out ${DESIGN}.repacked.place \
-  --absorb_buffer_luts on \
-  >repack.log 2>&1
+JSON_ARGS=
+if [ ! -z "${JSON}" ]; then
+  JSON_ARGS=--repacking-constraints ${JSON}
 fi
+
+python3 ${REPACK} \
+  --vpr-arch ${ARCH_DEF} \
+  --repacking-rules ${RULES} \
+  $JSON_ARGS \
+  --eblif-in ${DESIGN}.eblif \
+  --net-in ${DESIGN}.net \
+  --place-in ${DESIGN}.place \
+  --eblif-out ${DESIGN}.repacked.eblif \
+  --net-out ${DESIGN}.repacked.net \
+  --place-out ${DESIGN}.repacked.place \
+  --absorb_buffer_luts on \
+  >repack.log 2>&1

--- a/quicklogic/common/toolchain_wrappers/vpr_common
+++ b/quicklogic/common/toolchain_wrappers/vpr_common
@@ -1,8 +1,8 @@
 #!/bin/bash
 function parse_args {
 
-     OPTS=d:f:e:p:n:P:j:s:t:
-     LONGOPTS=device:,eblif:,pcf:,net:,part:,json:,sdc:,top:
+     OPTS=d:f:e:p:n:P:j:s:t:c:
+     LONGOPTS=device:,eblif:,pcf:,net:,part:,json:,sdc:,top:,corner:
 
      PARSED_OPTS=`getopt --options=${OPTS} --longoptions=${LONGOPTS} --name $0 -- $@`
      eval set -- ${PARSED_OPTS}
@@ -17,6 +17,7 @@ function parse_args {
      SDC=""
      JSON=""
      TOP="top"
+     CORNER=""
 
      while true; do
           case "$1" in
@@ -44,16 +45,20 @@ function parse_args {
                     PART=$2
                     shift 2
                     ;;
-	       -j|--json) 
-		    JSON=$2
-	            shift 2
-	            ;;	     
+	          -j|--json)
+		          JSON=$2
+	               shift 2
+	               ;;
                -s|--sdc)
                     SDC=$2
                     shift 2
                     ;;
                -t|--top)
                     TOP=$2
+                    shift 2
+                    ;;
+               -c|--corner)
+                    CORNER=$2
                     shift 2
                     ;;
                --)
@@ -84,14 +89,14 @@ function parse_args {
      export NET=$NET
      export SDC=$SDC
      export JSON=$JSON
+     export CORNER=$CORNER
      if [[ "$DEVICE" == "qlf_k4n8_qlf_k4n8" ]]; then
-	     DEVICE_1="qlf_k4n8-qlf_k4n8_umc22"
+	     DEVICE_1="qlf_k4n8-qlf_k4n8_umc22_${CORNER}"
      fi
      export TOP=$TOP
 
      export ARCH_DIR=`realpath ${MYPATH}/../share/symbiflow/arch/${DEVICE_1}_${DEVICE_1}`
      export ARCH_DEF=${ARCH_DIR}/arch_${DEVICE_1}_${DEVICE_1}.xml
-#     export RR_GRAPH=${ARCH_DIR}/rr_graph_${DEVICE_1}_${DEVICE_1}.rr_graph.real.bin
      export RR_GRAPH=${ARCH_DIR}/${DEVICE_1}.rr_graph.bin
      export PLACE_DELAY=${ARCH_DIR}/rr_graph_${DEVICE_1}_${DEVICE_1}.place_delay.bin
      export ROUTE_DELAY=${ARCH_DIR}/rr_graph_${DEVICE_1}_${DEVICE_1}.lookahead.bin

--- a/quicklogic/qlf_k4n8/boards.cmake
+++ b/quicklogic/qlf_k4n8/boards.cmake
@@ -1,9 +1,22 @@
+set(SLOW_CORNER_DEVICE "qlf_k4n8-qlf_k4n8_umc22_slow")
+set(FAST_CORNER_DEVICE "qlf_k4n8-qlf_k4n8_umc22_fast")
+
 add_quicklogic_board(
-  BOARD      qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD      ${FAST_CORNER_DEVICE}_board
   FAMILY     qlf_k4n8
-  DEVICE     qlf_k4n8-qlf_k4n8_umc22
+  DEVICE     ${FAST_CORNER_DEVICE}
   PINMAP_XML interface-mapping_24x24.xml
-  PACKAGE    qlf_k4n8-qlf_k4n8_umc22
+  PACKAGE    ${FAST_CORNER_DEVICE}
+  PINMAP     qlf_k4n8-qlf_k4n8_umc22.csv
+  FABRIC_PACKAGE qlf_k4n8_umc22
+)
+
+add_quicklogic_board(
+  BOARD      ${SLOW_CORNER_DEVICE}_board
+  FAMILY     qlf_k4n8
+  DEVICE     ${SLOW_CORNER_DEVICE}
+  PINMAP_XML interface-mapping_24x24.xml
+  PACKAGE    ${SLOW_CORNER_DEVICE}
   PINMAP     qlf_k4n8-qlf_k4n8_umc22.csv
   FABRIC_PACKAGE qlf_k4n8_umc22
 )

--- a/quicklogic/qlf_k4n8/devices/umc22/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/devices/umc22/CMakeLists.txt
@@ -1,14 +1,31 @@
 set(ARCH qlf_k4n8)
 
+set(ARCH_DIR ${QLF_FPGA_DATABASE_DIR}/${ARCH})
+
+set(FAST_CORNER_ARCH_DIR ${ARCH_DIR}/fast)
 quicklogic_define_qlf_device (
-  NAME     ${ARCH}_umc22
+  NAME     ${ARCH}_umc22_fast
   ARCH     ${ARCH}
   FAMILY   ${ARCH}
   LAYOUT   24x24
-  ARCH_XML ${QLF_FPGA_DATABASE_DIR}/${ARCH}/vpr_arch/UMC22nm_vpr.xml
-  RR_GRAPH ${QLF_FPGA_DATABASE_DIR}/${ARCH}/vpr_rr_graph/UMC22nm_vpr.bin.gz
+  ARCH_XML ${FAST_CORNER_ARCH_DIR}/vpr_arch/UMC22nm_vpr.xml
+  RR_GRAPH ${FAST_CORNER_ARCH_DIR}/vpr_rr_graph/UMC22nm_vpr.bin.gz
 
-  REPACKING_RULES ${QLF_FPGA_DATABASE_DIR}/${ARCH}/vpr_arch/repacking_rules.json
+  REPACKING_RULES ${ARCH_DIR}/repacking_rules.json
+
+  ROUTE_CHAN_WIDTH 60
+)
+
+set(SLOW_CORNER_ARCH_DIR ${ARCH_DIR}/slow)
+quicklogic_define_qlf_device (
+  NAME     ${ARCH}_umc22_slow
+  ARCH     ${ARCH}
+  FAMILY   ${ARCH}
+  LAYOUT   24x24
+  ARCH_XML ${SLOW_CORNER_ARCH_DIR}/vpr_arch/UMC22nm_vpr.xml
+  RR_GRAPH ${SLOW_CORNER_ARCH_DIR}/vpr_rr_graph/UMC22nm_vpr.bin.gz
+
+  REPACKING_RULES ${ARCH_DIR}/repacking_rules.json
 
   ROUTE_CHAN_WIDTH 60
 )

--- a/quicklogic/qlf_k4n8/tests/design_flow/IR_Remote/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/IR_Remote/CMakeLists.txt
@@ -13,7 +13,7 @@ add_file_target(FILE ${CURR_DIR}/IR_Emitter_Registers.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME IR_Remote_test-umc22-no-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/IR_Remote.v ${CURR_DIR}/r1024x9_1024x9.v ${CURR_DIR}/IR_Emitter_Carrier_Generator.v ${CURR_DIR}/i2cSlave.v ${CURR_DIR}/i2cSlaveTop.v ${CURR_DIR}/i2cSlaveSerialInterface.v ${CURR_DIR}/IR_Emitter_Interface.v ${CURR_DIR}/IR_Emitter_Modulator.v ${CURR_DIR}/IR_Emitter_Registers.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -22,7 +22,7 @@ add_fpga_target(
 add_fpga_target(
   NAME IR_Remote_test-umc22-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/IR_Remote.v ${CURR_DIR}/r1024x9_1024x9.v ${CURR_DIR}/IR_Emitter_Carrier_Generator.v ${CURR_DIR}/i2cSlave.v ${CURR_DIR}/i2cSlaveTop.v ${CURR_DIR}/i2cSlaveSerialInterface.v ${CURR_DIR}/IR_Emitter_Interface.v ${CURR_DIR}/IR_Emitter_Modulator.v ${CURR_DIR}/IR_Emitter_Registers.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/adder_128/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/adder_128/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/adder_128.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME adder_128_test-umc22-no-adder
   TOP adder_128
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/adder_128.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME adder_128_test-umc22-adder
   TOP adder_128
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/adder_128.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/adder_64/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/adder_64/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/adder_64.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME adder_64_test-umc22-no-adder
   TOP adder_64
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/adder_64.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME adder_64_test-umc22-adder
   TOP adder_64
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/adder_64.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/adder_8/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/adder_8/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/adder_8.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME adder_8_test1-umc22-no-adder
   TOP adder_8
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/adder_8.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME adder_8_test1-umc22-adder
   TOP adder_8
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/adder_8.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/adder_FFs/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/adder_FFs/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/adder_FFs.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME adder_FFs_test-umc22-no-adder
   TOP adder_FFs
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/adder_FFs.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME adder_FFs_test-umc22-adder
   TOP adder_FFs
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/adder_FFs.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/and2/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/and2/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/and2.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME and2_test-umc22-no-adder
   TOP and2
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/and2.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME and2_test-umc22-adder
   TOP and2
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/and2.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/and2_latch/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/and2_latch/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/and2_latch.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME and2_latch_test-umc22-no-adder
   TOP and2_latch
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/and2_latch.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME and2_latch_test-umc22-adder
   TOP and2_latch
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/and2_latch.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/bin2bcd/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/bin2bcd/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/bin2bcd.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME bin2bcd_test-umc22-no-adder
   TOP bin2bcd
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/bin2bcd.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME bin2bcd_test-umc22-adder
   TOP bin2bcd
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/bin2bcd.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/clock_tree_design/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/clock_tree_design/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/clock_tree_design.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME clock_tree_design_test-umc22-no-adder
   TOP clock_tree_design
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/clock_tree_design.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME clock_tree_design_test-umc22-adder
   TOP clock_tree_design
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/clock_tree_design.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/counter_16bit/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/counter_16bit/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/counter_16bit.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME counter_16bit_test-umc22-no-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/counter_16bit.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME counter_16bit_test-umc22-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/counter_16bit.v
   EXPLICIT_ADD_FILE_TARGET
 )

--- a/quicklogic/qlf_k4n8/tests/design_flow/counter_4clk/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/counter_4clk/CMakeLists.txt
@@ -6,7 +6,7 @@ add_file_target(FILE test.pcf)
 add_fpga_target(
   NAME counter_4clk-umc22-no-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/counter_4clk.v
   INPUT_IO_FILE test.pcf
   INPUT_SDC_FILE counter_4clk.sdc
@@ -18,7 +18,7 @@ add_fpga_target(
 add_fpga_target(
   NAME counter_4clk-umc22-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/counter_4clk.v
   INPUT_IO_FILE test.pcf
   INPUT_SDC_FILE counter_4clk.sdc

--- a/quicklogic/qlf_k4n8/tests/design_flow/full_adder/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/full_adder/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/full_adder.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME full_adder_test-umc22-no-adder
   TOP full_adder
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/full_adder.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME full_adder_test-umc22-adder
   TOP full_adder
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/full_adder.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/io_reg/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/io_reg/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/io_reg.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME io_reg_test-umc22-no-adder
   TOP io_reg
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/io_reg.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME io_reg_test-umc22-adder
   TOP io_reg
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/io_reg.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/io_reg_tc1/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/io_reg_tc1/CMakeLists.txt
@@ -7,7 +7,7 @@ add_file_target(FILE ${CURR_DIR}/mux.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME io_reg_tc1_test-umc22-no-adder
   TOP io_reg_tc1
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/io_reg_tc1.v ${CURR_DIR}/demux.v ${CURR_DIR}/mux.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -16,7 +16,7 @@ add_fpga_target(
 add_fpga_target(
   NAME io_reg_tc1_test-umc22-adder
   TOP io_reg_tc1
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/io_reg_tc1.v ${CURR_DIR}/demux.v ${CURR_DIR}/mux.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/io_tc1/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/io_tc1/CMakeLists.txt
@@ -7,9 +7,18 @@ add_file_target(FILE ${IO_TC1_DEMUX} SCANNER_TYPE verilog)
 add_file_target(FILE ${IO_TC1_MUX} SCANNER_TYPE verilog)
 
 add_fpga_target(
+  NAME io_tc1_test-umc22-no-adder
+  TOP io_tc1
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
+  SOURCES ${IO_TC1} ${IO_TC1_DEMUX} ${IO_TC1_MUX}
+  EXPLICIT_ADD_FILE_TARGET
+  DEFINES SYNTH_OPTS=-no_adder
+  )
+
+add_fpga_target(
   NAME io_tc1_test-umc22-adder
   TOP io_tc1
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${IO_TC1} ${IO_TC1_DEMUX} ${IO_TC1_MUX}
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/jpeg_qnr/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/jpeg_qnr/CMakeLists.txt
@@ -6,7 +6,7 @@ add_file_target(FILE ${CURR_DIR}/div_uu.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME jpeg_qnr_test-umc22-no-adder
   TOP jpeg_qnr
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/jpeg_qnr.v ${CURR_DIR}/div_su.v ${CURR_DIR}/div_uu.v 
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -15,7 +15,7 @@ add_fpga_target(
 add_fpga_target(
   NAME jpeg_qnr_test-umc22-adder
   TOP jpeg_qnr
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/jpeg_qnr.v ${CURR_DIR}/div_su.v ${CURR_DIR}/div_uu.v 
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/lut4_8ffs/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/lut4_8ffs/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/lut4_8ffs.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME lut4_8ffs_test-umc22-no-adder
   TOP lut4_8ffs
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/lut4_8ffs.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME lut4_8ffs_test-umc22-adder
   TOP lut4_8ffs
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/lut4_8ffs.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/multi_enc_decx2x4/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/multi_enc_decx2x4/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/multi_enc_decx2x4.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME multi_enc_decx2x4_test-umc22-no-adder
   TOP multi_enc_decx2x4
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/multi_enc_decx2x4.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME multi_enc_decx2x4_test-umc22-adder
   TOP multi_enc_decx2x4
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/multi_enc_decx2x4.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/multiplier_8bit/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/multiplier_8bit/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/multiplier_8bit.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME multiplier_8bit_test-umc22-no-adder
   TOP multiplier_8bit
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/multiplier_8bit.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME multiplier_8bit_test-umc22-adder
   TOP multiplier_8bit
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/multiplier_8bit.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/routing_test/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/routing_test/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/routing_test.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME routing_test_test-umc22-no-adder
   TOP routing_test
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/routing_test.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME routing_test_test-umc22-adder
   TOP routing_test
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/routing_test.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/rs_decoder_1/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/rs_decoder_1/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/rs_decoder_1.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME rs_decoder_1_test-umc22-no-adder
   TOP rs_decoder_1
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/rs_decoder_1.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME rs_decoder_1_test-umc22-adder
   TOP rs_decoder_1
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/rs_decoder_1.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/sdio_client_top/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/sdio_client_top/CMakeLists.txt
@@ -22,7 +22,7 @@ add_file_target(FILE ${CURR_DIR}/sync.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME sdio_client_top_test-umc22-no-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/af512x9_512x9.v ${CURR_DIR}/cmd_control.v ${CURR_DIR}/crc16.v ${CURR_DIR}/crc7.v ${CURR_DIR}/dat0_line.v ${CURR_DIR}/dat123_line.v ${CURR_DIR}/dat1_line.v ${CURR_DIR}/dat23_line.v ${CURR_DIR}/dat_control.v ${CURR_DIR}/dat_fifo.v ${CURR_DIR}/function1.v ${CURR_DIR}/function2.v ${CURR_DIR}/registers.v ${CURR_DIR}/sdio_client_top.v ${CURR_DIR}/spi_cmd_datin_line.v ${CURR_DIR}/spi_crc16.v ${CURR_DIR}/spi_dat_control.v ${CURR_DIR}/sync.v 
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -31,7 +31,7 @@ add_fpga_target(
 add_fpga_target(
   NAME sdio_client_top_test-umc22-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/af512x9_512x9.v ${CURR_DIR}/cmd_control.v ${CURR_DIR}/crc16.v ${CURR_DIR}/crc7.v ${CURR_DIR}/dat0_line.v ${CURR_DIR}/dat123_line.v ${CURR_DIR}/dat1_line.v ${CURR_DIR}/dat23_line.v ${CURR_DIR}/dat_control.v ${CURR_DIR}/dat_fifo.v ${CURR_DIR}/function1.v ${CURR_DIR}/function2.v ${CURR_DIR}/registers.v ${CURR_DIR}/sdio_client_top.v ${CURR_DIR}/spi_cmd_datin_line.v ${CURR_DIR}/spi_crc16.v ${CURR_DIR}/spi_dat_control.v ${CURR_DIR}/sync.v 
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/shift_reg_1024/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/shift_reg_1024/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/shift_reg_1024.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME shift_reg_1024_test-umc22-no-adder
   TOP shift_reg_1024
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/shift_reg_1024.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME shift_reg_1024_test-umc22-adder
   TOP shift_reg_1024
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/shift_reg_1024.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/shift_reg_576/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/shift_reg_576/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/shift_reg_576.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME shift_reg_576_test-umc22-no-adder
   TOP shift_reg_576
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/shift_reg_576.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME shift_reg_576_test-umc22-adder
   TOP shift_reg_576
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/shift_reg_576.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/shift_reg_8/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/shift_reg_8/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/shift_reg_8.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME shift_reg_8_test-umc22-no-adder
   TOP shift_reg_8
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/shift_reg_8.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME shift_reg_8_test-umc22-adder
   TOP shift_reg_8
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/shift_reg_8.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/spi_master_top/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/spi_master_top/CMakeLists.txt
@@ -9,7 +9,7 @@ add_file_target(FILE ${CURR_DIR}/serializer_deserializer.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME spi_master_top_test-umc22-no-adder
   TOP spi_master_top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/spi_master_top.v ${CURR_DIR}/registers.v ${CURR_DIR}/serializer_deserializer.v ${CURR_DIR}/baud_generator.v ${CURR_DIR}/ql_clkgate_x4.v ${CURR_DIR}/ql_mux2_x2.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -18,7 +18,7 @@ add_fpga_target(
 add_fpga_target(
   NAME spi_master_top_test-umc22-adder
   TOP spi_master_top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/spi_master_top.v ${CURR_DIR}/registers.v ${CURR_DIR}/serializer_deserializer.v ${CURR_DIR}/baud_generator.v ${CURR_DIR}/ql_clkgate_x4.v ${CURR_DIR}/ql_mux2_x2.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/design_flow/top_120_13/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/design_flow/top_120_13/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/top_120_13.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME top_120_13_test-umc22-no-adder
   TOP top_120_13
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/top_120_13.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME top_120_13_test-umc22-adder
   TOP top_120_13
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/top_120_13.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/features/adder_columns/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/adder_columns/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${ADDER_C} SCANNER_TYPE verilog)
 add_fpga_target(
   NAME adder_columns_test2-umc22-adder
   TOP adder_columns
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${ADDER_C}
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/features/adder_max/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/adder_max/CMakeLists.txt
@@ -5,7 +5,7 @@ add_file_target(FILE ${ADDER_M} SCANNER_TYPE verilog)
 add_fpga_target(
   NAME adder_max_test2-umc22-adder
   TOP adder_max
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${ADDER_M}
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/features/bit_file/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/bit_file/CMakeLists.txt
@@ -10,7 +10,7 @@ add_file_target(FILE ${CURR_DIR}/dct_mac.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME dct_mac_test-umc22-adder
   TOP dct_mac
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/dct_mac.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/features/fasm_file/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/fasm_file/CMakeLists.txt
@@ -10,7 +10,7 @@ set(BITSTREAM ${CMAKE_CURRENT_BINARY_DIR}/dct_mac_test2-umc22-adder/qlf_k4n8-${Q
 add_fpga_target(
   NAME dct_mac_test2-umc22-adder
   TOP dct_mac
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${DCT_MAC}
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/features/io_max/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/io_max/CMakeLists.txt
@@ -10,7 +10,7 @@ add_file_target(FILE ${IO1_MUX} SCANNER_TYPE verilog)
 add_fpga_target(
   NAME io_max_test-umc22-adder
   TOP io_max
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${IO_MAX} ${IO1_DEMUX} ${IO1_MUX}
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/features/io_reg_max/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/io_reg_max/CMakeLists.txt
@@ -10,7 +10,7 @@ add_file_target(FILE ${IO_MUX} SCANNER_TYPE verilog)
 add_fpga_target(
   NAME io_reg_max_test-umc22-adder
   TOP io_reg_max
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${IO_REG_MAX} ${IO_DEMUX} ${IO_MUX}
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/features/pcf_option/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/pcf_option/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE clock_tree_design.pcf)
 add_fpga_target(
   NAME clock_tree_design_test2-umc22-adder
   TOP clock_tree_design
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   INPUT_IO_FILE clock_tree_design.pcf
   SOURCES ${CLK_TREE}
   EXPLICIT_ADD_FILE_TARGET

--- a/quicklogic/qlf_k4n8/tests/features/post_synthesis_file/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/post_synthesis_file/CMakeLists.txt
@@ -10,7 +10,7 @@ set(BITSTREAM ${CMAKE_CURRENT_BINARY_DIR}/counter_16bit_test2-umc22-adder/qlf_k4
 add_fpga_target(
   NAME counter_16bit_test2-umc22-adder
   TOP top
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${COUNTER_16BIT}
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/features/sdc_option/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/sdc_option/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE shift_reg_8.sdc SCANNER_TYPE)
 add_fpga_target(
   NAME shift_reg_8_test2-umc22-adder
   TOP shift_reg_8
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${SHIFT_REG_8}
   INPUT_SDC_FILE shift_reg_8.sdc
   EXPLICIT_ADD_FILE_TARGET

--- a/quicklogic/qlf_k4n8/tests/features/shift_reg_4608/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/shift_reg_4608/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/shift_reg_4608.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME shift_reg_4608_test-umc22-adder
   TOP shift_reg_4608
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/shift_reg_4608.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/synth_flow/des_perf/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/synth_flow/des_perf/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/des_perf.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME des_perf_test-umc22-no-adder
   TOP des_perf
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/des_perf.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME des_perf_test-umc22-adder
   TOP des_perf
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/des_perf.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/synth_flow/iir/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/synth_flow/iir/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/iir.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME iir_test-umc22-no-adder
   TOP iir
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/iir.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME iir_test-umc22-adder
   TOP iir
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/iir.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/tests/synth_flow/rgb2ycrcb/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/synth_flow/rgb2ycrcb/CMakeLists.txt
@@ -4,7 +4,7 @@ add_file_target(FILE ${CURR_DIR}/rgb2ycrcb.v SCANNER_TYPE verilog)
 add_fpga_target(
   NAME rgb2ycrcb_test-umc22-no-adder
   TOP rgb2ycrcb
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/rgb2ycrcb.v
   EXPLICIT_ADD_FILE_TARGET
   DEFINES SYNTH_OPTS=-no_adder
@@ -13,7 +13,7 @@ add_fpga_target(
 add_fpga_target(
   NAME rgb2ycrcb_test-umc22-adder
   TOP rgb2ycrcb
-  BOARD qlf_k4n8-qlf_k4n8_umc22_board
+  BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/rgb2ycrcb.v
   EXPLICIT_ADD_FILE_TARGET
   )

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/test_lut_padding.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/test_lut_padding.py
@@ -33,10 +33,10 @@ def test_lut_padding(monkeypatch, lut_width, lut_inputs):
     )
 
     vpr_arch = os.path.join(
-        qlfpga_plugins, "qlf_k4n8/vpr_arch/UMC22nm_vpr.xml"
+        qlfpga_plugins, "qlf_k4n8/slow/vpr_arch/UMC22nm_vpr.xml"
     )
     repacking_rules = os.path.join(
-        qlfpga_plugins, "qlf_k4n8/vpr_arch/repacking_rules.json"
+        qlfpga_plugins, "qlf_k4n8/repacking_rules.json"
     )
 
     eblif_ref = os.path.join(

--- a/quicklogic/qlf_k6n10/tests/design_flow/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/CMakeLists.txt
@@ -5,13 +5,15 @@ add_subdirectory(and2)
 add_subdirectory(and2_latch)
 add_subdirectory(bin2bcd)
 add_subdirectory(rs_decoder_1)
-add_subdirectory(unsigned_mult_80)
+# TODO: this design takes quite a large amount of time to complete, due to congestion.
+#add_subdirectory(unsigned_mult_80)
 add_subdirectory(adder_64)
 add_subdirectory(top_120_13)
 add_subdirectory(multiplier_8bit)
-add_subdirectory(shift_reg_8192)
-add_subdirectory(bram)
-add_subdirectory(mac_16)
+# TODO: re-enable these tests once the ql-design submodule is updated with the designs.
+#add_subdirectory(shift_reg_8192)
+#add_subdirectory(bram)
+#add_subdirectory(mac_16)
 
 #The k6n10 architecture can be scaled up to be able to run
 #Ressource consuming testcases below

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(FULL_BOARDS dummy_ice40_hx1k_tq144 qlf_k4n8-qlf_k4n8_umc22_board)
+set(FULL_BOARDS dummy_ice40_hx1k_tq144 qlf_k4n8-qlf_k4n8_umc22_slow_board)
 if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})
 list(APPEND FULL_BOARDS dummy_artix7_xc7a50t-basys3_test)
 endif()


### PR DESCRIPTION
This PR adds two different devices and boards for two different corners.

The CMake infrastructure does not allow for a same device to use different arch XML and RR graphs (that have different corner data).

The multiple corner testing can be properly added to the installation package testing suite (which still needs to be developed) so that we can allow and test usage of different corners for the same device during different parts of the flow (e.g. SLOW corner for PnR and FAST corner for analysis).

With this PR, the `ql_symbiflow` script is adapted so to perform PnR with `slow` and Post-PnR analysis with `fast` corners by default.

TODO:
 - [x] change generation script to allow the generation of different corners archs and rr_graph
 - [x] add slow and fast corners arch and rr_graph in quicklogic-symbiflow-plugin
