### PR TITLE
Disabling qlf_k6n10 testcases as they stall CI

### DIFF
--- a/quicklogic/qlf_k6n10/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/CMakeLists.txt
@@ -26,4 +26,6 @@ quicklogic_define_qlf_arch(
 add_subdirectory(devices)
 include(boards.cmake)
 
-add_subdirectory(tests)
+# qlf_k6n10 arch is too large, testcases are stalling CI runs.
+# Test are disabled until the test benchmark is setup.
+#add_subdirectory(tests)

--- a/quicklogic/qlf_k6n10/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/CMakeLists.txt
@@ -26,6 +26,5 @@ quicklogic_define_qlf_arch(
 add_subdirectory(devices)
 include(boards.cmake)
 
-# qlf_k6n10 arch is too large, testcases are stalling CI runs.
-# Test are disabled until the test benchmark is setup.
-#add_subdirectory(tests)
+
+add_subdirectory(tests)

--- a/quicklogic/qlf_k6n10/tests/design_flow/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Testcases for the design flow
 add_subdirectory(counter)
 add_subdirectory(adder_8)
-add_subdirectory(bram)
+#add_subdirectory(bram)
 
 # The k6n10 architecture is too large, having a lot of testcase is stalling CI.
 # Testcases will be enabled after test benchmark is set up.

--- a/quicklogic/qlf_k6n10/tests/design_flow/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/CMakeLists.txt
@@ -1,17 +1,21 @@
 #Testcases for the design flow
 add_subdirectory(counter)
 add_subdirectory(adder_8)
-add_subdirectory(and2)
-add_subdirectory(and2_latch)
-add_subdirectory(bin2bcd)
-add_subdirectory(rs_decoder_1)
-add_subdirectory(unsigned_mult_80)
-add_subdirectory(adder_64)
-add_subdirectory(top_120_13)
-add_subdirectory(multiplier_8bit)
-add_subdirectory(shift_reg_8192)
 add_subdirectory(bram)
-add_subdirectory(mac_16)
+
+# The k6n10 architecture is too large, having a lot of testcase is stalling CI.
+# Testcases will be enabled after test benchmark is set up.
+
+#add_subdirectory(and2)
+#add_subdirectory(and2_latch)
+#add_subdirectory(bin2bcd)
+#add_subdirectory(rs_decoder_1)
+#add_subdirectory(unsigned_mult_80)
+#add_subdirectory(adder_64)
+#add_subdirectory(top_120_13)
+#add_subdirectory(multiplier_8bit)
+#add_subdirectory(shift_reg_8192)
+#add_subdirectory(mac_16)
 
 #The k6n10 architecture can be scaled up to be able to run
 #Ressource consuming testcases below

--- a/quicklogic/qlf_k6n10/tests/design_flow/adder_8/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/adder_8/CMakeLists.txt
@@ -17,5 +17,5 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_qlf_k6n10_tests_no_adder adder_8-gf12-no-adder_route)
+#add_dependencies(all_qlf_k6n10_tests_no_adder adder_8-gf12-no-adder_route)
 add_dependencies(all_qlf_k6n10_tests_adder    adder_8-gf12-adder_route)

--- a/quicklogic/qlf_k6n10/tests/design_flow/adder_8/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/adder_8/CMakeLists.txt
@@ -1,12 +1,14 @@
 set(ADDER_8 ${QL_DESIGNS_DIR}/adder_8/adder_8.v)
 
-add_fpga_target(
-  NAME adder_8-gf12-no-adder
-  BOARD qlf_k6n10-qlf_k6n10_gf12_board
-  SOURCES ${ADDER_8}
-  EXPLICIT_ADD_FILE_TARGET
-  DEFINES SYNTH_OPTS=-no_adder
-)
+#Disabled mode to avoid Stalling CI, will be enabled after test benchmark is set up.
+
+#add_fpga_target(
+#  NAME adder_8-gf12-no-adder
+#  BOARD qlf_k6n10-qlf_k6n10_gf12_board
+#  SOURCES ${ADDER_8}
+#  EXPLICIT_ADD_FILE_TARGET
+#  DEFINES SYNTH_OPTS=-no_adder
+#)
 
 add_fpga_target(
   NAME adder_8-gf12-adder

--- a/quicklogic/qlf_k6n10/tests/design_flow/bram/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/bram/CMakeLists.txt
@@ -20,21 +20,23 @@ add_fpga_target(
   DEFINES TOP=BRAM_16x1024
   )
 
-add_fpga_target(
-  NAME bram-gf12-mode2
-  BOARD qlf_k6n10-qlf_k6n10_gf12_board
-  SOURCES ${BRAM}
-  EXPLICIT_ADD_FILE_TARGET
-  DEFINES TOP=BRAM_8x2048
-  )
+#Disabled mode to avoid Stalling CI, will be enabled after test benchmark is set up.
 
-add_fpga_target(
-  NAME bram-gf12-mode3
-  BOARD qlf_k6n10-qlf_k6n10_gf12_board
-  SOURCES ${BRAM}
-  EXPLICIT_ADD_FILE_TARGET
-  DEFINES TOP=BRAM_4x4096
-  )
+#add_fpga_target(
+#  NAME bram-gf12-mode2
+#  BOARD qlf_k6n10-qlf_k6n10_gf12_board
+#  SOURCES ${BRAM}
+#  EXPLICIT_ADD_FILE_TARGET
+#  DEFINES TOP=BRAM_8x2048
+#  )
+
+#add_fpga_target(
+#  NAME bram-gf12-mode3
+#  BOARD qlf_k6n10-qlf_k6n10_gf12_board
+#  SOURCES ${BRAM}
+#  EXPLICIT_ADD_FILE_TARGET
+#  DEFINES TOP=BRAM_4x4096
+#  )
 
 add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode0_route)
 add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode1_route)

--- a/quicklogic/qlf_k6n10/tests/design_flow/bram/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/bram/CMakeLists.txt
@@ -40,5 +40,5 @@ add_fpga_target(
 
 add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode0_route)
 add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode1_route)
-add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode2_route)
-add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode3_route)
+#add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode2_route)
+#add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode3_route)

--- a/quicklogic/qlf_k6n10/tests/design_flow/counter/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/counter/CMakeLists.txt
@@ -19,4 +19,4 @@ add_fpga_target(
 #  )
 
 add_dependencies(all_qlf_k6n10_tests_no_adder counter-gf12-no-adder_route)
-add_dependencies(all_qlf_k6n10_tests_adder    counter-gf12-adder_route)
+#add_dependencies(all_qlf_k6n10_tests_adder    counter-gf12-adder_route)

--- a/quicklogic/qlf_k6n10/tests/design_flow/counter/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/counter/CMakeLists.txt
@@ -9,12 +9,14 @@ add_fpga_target(
   DEFINES SYNTH_OPTS=-no_adder
 )
 
-add_fpga_target(
-  NAME counter-gf12-adder
-  BOARD qlf_k6n10-qlf_k6n10_gf12_board
-  SOURCES ${COUNTER}
-  EXPLICIT_ADD_FILE_TARGET
-  )
+#Disabled mode to avoid Stalling CI, will be enabled after test benchmark is set up.
+
+#add_fpga_target(
+#  NAME counter-gf12-adder
+#  BOARD qlf_k6n10-qlf_k6n10_gf12_board
+#  SOURCES ${COUNTER}
+#  EXPLICIT_ADD_FILE_TARGET
+#  )
 
 add_dependencies(all_qlf_k6n10_tests_no_adder counter-gf12-no-adder_route)
 add_dependencies(all_qlf_k6n10_tests_adder    counter-gf12-adder_route)


### PR DESCRIPTION
This PR disable qlf_k6n10 testcases since they are stalling CI.
A benchmark will be set up to run the tests in a following PR.

Signed-off-by: samycharas <samy.charas@cpe.fr>