### PR TITLE
Enable testcases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,27 @@ jobs:
 
     - uses: actions/checkout@v2
       with:
+        lfs: 'true'
         submodules: recursive
 
     - name: Install
       run: |
         sudo apt-get update
-        sudo apt-get install git g++-6 colordiff coreutils graphviz inkscape make cmake
+        sudo apt-get install git git-lfs g++-6 colordiff coreutils graphviz inkscape make cmake
+        sudo git lfs install
+    - name: generate lfs file list
+      run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+    - name: restore lfs cache
+      uses: actions/cache@v2
+      id: lfs-cache
+      with:
+        path: recursive
+        key: recursive
+
+    - name: pull lfs files
+      uses: actions/checkout@v2
+    - run: git lfs pull
 
     - name: Execute test script
       run: stdbuf -i0 -o0 -e0 ./.github/ci/test.sh

--- a/quicklogic/qlf_k6n10/tests/design_flow/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/CMakeLists.txt
@@ -5,14 +5,13 @@ add_subdirectory(and2)
 add_subdirectory(and2_latch)
 add_subdirectory(bin2bcd)
 add_subdirectory(rs_decoder_1)
-# TODO: this design takes quite a large amount of time to complete, due to congestion.
-#add_subdirectory(unsigned_mult_80)
+add_subdirectory(unsigned_mult_80)
 add_subdirectory(adder_64)
 add_subdirectory(top_120_13)
 add_subdirectory(multiplier_8bit)
-# TODO: re-enable these tests once the ql-design submodule is updated with the designs.
-#add_subdirectory(shift_reg_8192)
-#add_subdirectory(bram)
+add_subdirectory(shift_reg_8192)
+add_subdirectory(bram)
+#TODO: Add this testcase after yosys plugin support dsp
 #add_subdirectory(mac_16)
 
 #The k6n10 architecture can be scaled up to be able to run

--- a/quicklogic/qlf_k6n10/tests/design_flow/adder_8/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/adder_8/CMakeLists.txt
@@ -1,14 +1,12 @@
 set(ADDER_8 ${QL_DESIGNS_DIR}/adder_8/adder_8.v)
 
-#Disabled mode to avoid Stalling CI, will be enabled after test benchmark is set up.
-
-#add_fpga_target(
-#  NAME adder_8-gf12-no-adder
-#  BOARD qlf_k6n10-qlf_k6n10_gf12_board
-#  SOURCES ${ADDER_8}
-#  EXPLICIT_ADD_FILE_TARGET
-#  DEFINES SYNTH_OPTS=-no_adder
-#)
+add_fpga_target(
+  NAME adder_8-gf12-no-adder
+  BOARD qlf_k6n10-qlf_k6n10_gf12_board
+  SOURCES ${ADDER_8}
+  EXPLICIT_ADD_FILE_TARGET
+  DEFINES SYNTH_OPTS=-no_adder
+)
 
 add_fpga_target(
   NAME adder_8-gf12-adder
@@ -17,5 +15,5 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-#add_dependencies(all_qlf_k6n10_tests_no_adder adder_8-gf12-no-adder_route)
+add_dependencies(all_qlf_k6n10_tests_no_adder adder_8-gf12-no-adder_route)
 add_dependencies(all_qlf_k6n10_tests_adder    adder_8-gf12-adder_route)

--- a/quicklogic/qlf_k6n10/tests/design_flow/bram/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/bram/CMakeLists.txt
@@ -20,25 +20,25 @@ add_fpga_target(
   DEFINES TOP=BRAM_16x1024
   )
 
-#Disabled mode to avoid Stalling CI, will be enabled after test benchmark is set up.
 
-#add_fpga_target(
-#  NAME bram-gf12-mode2
-#  BOARD qlf_k6n10-qlf_k6n10_gf12_board
-#  SOURCES ${BRAM}
-#  EXPLICIT_ADD_FILE_TARGET
-#  DEFINES TOP=BRAM_8x2048
-#  )
 
-#add_fpga_target(
-#  NAME bram-gf12-mode3
-#  BOARD qlf_k6n10-qlf_k6n10_gf12_board
-#  SOURCES ${BRAM}
-#  EXPLICIT_ADD_FILE_TARGET
-#  DEFINES TOP=BRAM_4x4096
-#  )
+add_fpga_target(
+  NAME bram-gf12-mode2
+  BOARD qlf_k6n10-qlf_k6n10_gf12_board
+  SOURCES ${BRAM}
+  EXPLICIT_ADD_FILE_TARGET
+  DEFINES TOP=BRAM_8x2048
+  )
+
+add_fpga_target(
+  NAME bram-gf12-mode3
+  BOARD qlf_k6n10-qlf_k6n10_gf12_board
+  SOURCES ${BRAM}
+  EXPLICIT_ADD_FILE_TARGET
+  DEFINES TOP=BRAM_4x4096
+  )
 
 add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode0_route)
 add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode1_route)
-#add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode2_route)
-#add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode3_route)
+add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode2_route)
+add_dependencies(all_qlf_k6n10_tests_adder    bram-gf12-mode3_route)

--- a/quicklogic/qlf_k6n10/tests/design_flow/counter/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/design_flow/counter/CMakeLists.txt
@@ -9,14 +9,12 @@ add_fpga_target(
   DEFINES SYNTH_OPTS=-no_adder
 )
 
-#Disabled mode to avoid Stalling CI, will be enabled after test benchmark is set up.
-
-#add_fpga_target(
-#  NAME counter-gf12-adder
-#  BOARD qlf_k6n10-qlf_k6n10_gf12_board
-#  SOURCES ${COUNTER}
-#  EXPLICIT_ADD_FILE_TARGET
-#  )
+add_fpga_target(
+  NAME counter-gf12-adder
+  BOARD qlf_k6n10-qlf_k6n10_gf12_board
+  SOURCES ${COUNTER}
+  EXPLICIT_ADD_FILE_TARGET
+  )
 
 add_dependencies(all_qlf_k6n10_tests_no_adder counter-gf12-no-adder_route)
-#add_dependencies(all_qlf_k6n10_tests_adder    counter-gf12-adder_route)
+add_dependencies(all_qlf_k6n10_tests_adder    counter-gf12-adder_route)


### PR DESCRIPTION
This PR enables testcases that were disabled previously due to CI runtime being too high.
RR graph has been corrected, and problematic designs are no longer taking long time to build.