### PR TITLE
Allow no PCF file for the repacker

### DIFF
--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -562,7 +562,7 @@ fi
 	cd \${BUILDDIR} && symbiflow_route -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.post_v: \${BUILDDIR}/\${TOP_FINAL}.route\n\
-	cd \${BUILDDIR} && symbiflow_analysis -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${ANALYSIS_CORNER} >> $LOG_FILE 2>&1\n\
+	cd \${BUILDDIR} && symbiflow_analysis -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${ANALYSIS_CORNER} -t \${TOP} >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.fasm: \${BUILDDIR}/\${TOP_FINAL}.route\n\
 	cd \${BUILDDIR} && symbiflow_write_fasm -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\

--- a/quicklogic/common/toolchain_wrappers/symbiflow_repack
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_repack
@@ -16,14 +16,19 @@ RULES=${ARCH_DIR}/${DEVICE_1}.repacking_rules.json
 
 JSON_ARGS=
 if [ ! -z "${JSON}" ]; then
-  JSON_ARGS=--json-constraints ${JSON}
+  JSON_ARGS="--json-constraints ${JSON}"
+fi
+
+PCF_ARGS=
+if [ ! -z "${PCF_PATH}" ]; then
+  PCF_ARGS="--pcf-constraints ${PCF_PATH}"
 fi
 
 python3 ${REPACK} \
   --vpr-arch ${ARCH_DEF} \
   --repacking-rules ${RULES} \
   $JSON_ARGS \
-  --pcf-constraints ${PCF_PATH}\
+  $PCF_ARGS \
   --eblif-in ${DESIGN}.eblif \
   --net-in ${DESIGN}.net \
   --place-in ${DESIGN}.place \


### PR DESCRIPTION
This PR allows for no PCF file to be provided to the repacker in the installed toolchain.