### PR TITLE
dependabot: raise PR limit to 30

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 30


### PR DESCRIPTION
We have 23 submodules at this moment and at least 23 PRs
are required to update them all.