### PR TITLE
K4N8 default bitstream support

### DIFF
--- a/quicklogic/common/toolchain_wrappers/conda_build_install_package.sh
+++ b/quicklogic/common/toolchain_wrappers/conda_build_install_package.sh
@@ -34,5 +34,5 @@ conda activate
 pip install python-constraint
 pip install serial
 pip install git+https://github.com/QuickLogic-Corp/quicklogic-fasm@318abca
-pip install git+https://github.com/QuickLogic-Corp/ql_fasm
+pip install git+https://github.com/QuickLogic-Corp/ql_fasm@e5d0915
 conda deactivate


### PR DESCRIPTION
This PR updated the `qlfpga-symbiflow-plugins` submodule so that the version that contains the default bitstream is used.