### PR TITLE
Symbiflow write xxx

### DIFF
--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -487,17 +487,17 @@ fi
 # EOS-S3 specific targets
 if [ "$DEVICE" == "ql-eos-s3" ]; then
     echo -e "\
-\${BUILDDIR}/\${TOP}_bit.h: \${BUILDDIR}/\${TOP}.bit\n\
-	cd \${BUILDDIR} && symbiflow_write_bitheader -b \${TOP}.bit >> $LOG_FILE 2>&1\n\
+\${TOP}_bit.h: \${BUILDDIR}/\${TOP}.bit\n\
+	symbiflow_write_bitheader \$^ \$@ >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.bin: \${BUILDDIR}/\${TOP}.bit\n\
 	cd \${BUILDDIR} && symbiflow_write_binary -b \${TOP}.bit >> $LOG_FILE 2>&1\n\
 \n\
-\${BUILDDIR}/\${TOP}.jlink: \${BUILDDIR}/\${TOP}.bit\n\
-	cd \${BUILDDIR} && symbiflow_write_jlink -f \${TOP}.fasm -P \${PACKAGENAME} -b \${TOP}.bit >> $LOG_FILE 2>&1\n\
+\${TOP}.jlink: \${BUILDDIR}/\${TOP}.bit\n\
+	symbiflow_write_jlink \$^ \$@ >> $LOG_FILE 2>&1\n\
 \n\
-\${BUILDDIR}/\${TOP}.openocd: \${BUILDDIR}/\${TOP}.bit\n\
-	cd \${BUILDDIR} && symbiflow_write_openocd -f \${TOP}.fasm -P \${PACKAGENAME} -b \${TOP}.bit >> $LOG_FILE 2>&1\n\
+\${TOP}.openocd: \${BUILDDIR}/\${TOP}.bit\n\
+	symbiflow_write_openocd \$^ \$@ >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}_jlink.h: \${BUILDDIR}/\${TOP}.jlink >> $LOG_FILE 2>&1\n\
 	cd \${BUILDDIR} && symbiflow_write_jlinkheader\n\

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -332,7 +332,6 @@ fi
 
 export PCF_FILE=$PCF
 export JSON=$JSON
-export TOP_F=$TOP
 export PINMAP_FILE=$PINMAPCSV
 export MAX_CRITICALITY=$MAX_CRITICALITY
 ##### Create Makefile #####

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_bitheader
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_bitheader
@@ -9,4 +9,4 @@ source ${MYPATH}/env
 JLINK2HEADER=`readlink -f ${MYPATH}/../bin/python/bitstream_to_header.py`
 
 
-python3 ${JLINK2HEADER} ${TOP_F}.bit ../${TOP_F}_bit.h
+python3 ${JLINK2HEADER} $@

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_bitheader
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_bitheader
@@ -6,7 +6,7 @@ MYPATH=$(dirname "$(readlink -f "$BASH_SOURCE")")
 
 source ${MYPATH}/env
 
-JLINK2HEADER=`readlink -f ${MYPATH}/../bin/python/bitstream_to_header.py`
+BIT2HEADER=`readlink -f ${MYPATH}/../bin/python/bitstream_to_header.py`
 
 
-python3 ${JLINK2HEADER} $@
+python3 ${BIT2HEADER} $@

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_jlink
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_jlink
@@ -9,4 +9,4 @@ source ${MYPATH}/env
 BIT2JLINK=`readlink -f ${MYPATH}/../bin/python/bitstream_to_jlink.py`
 
 echo "Generating bit.jlink"
-python3 ${BIT2JLINK} ${TOP_F}.bit ../${TOP_F}.jlink
+python3 ${BIT2JLINK} $@

--- a/quicklogic/common/toolchain_wrappers/symbiflow_write_openocd
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_write_openocd
@@ -9,4 +9,4 @@ source ${MYPATH}/env
 BIT2OPENOCD=`readlink -f ${MYPATH}/../bin/python/bitstream_to_openocd.py`
 
 echo "Generating bit.openocd"
-python3 ${BIT2OPENOCD} ${TOP_F}.bit ../${TOP_F}.openocd
+python3 ${BIT2OPENOCD} $@


### PR DESCRIPTION
most of the `symbiflow_write_xxx` uses env var `TOP_F` exported by `ql_symbiflow` to provides hardcoded path based on this variable for input and output file when it calls corresponding python script
Consequently calling  directly `make -f Makefile_symbiflow` or using manually one of these script fails (as mentionned in #538) due to missing `TOP_F` var.

This PR modify behaviour of this scripts to pass directly scripts parameters to the python script.

`ql_symbiflow` is also modified to pass correct arguments (ie .bit and target file).

Note: `symbiflow_write_binary` is absent to the master branch and `symbiflow_write_jlinkheader` seems totally absent. This why corresponding rules are not modified