### PR TITLE
A fix to PP3 toolchain wrappers

### DIFF
--- a/quicklogic/common/cmake/run_toolchain_test.cmake
+++ b/quicklogic/common/cmake/run_toolchain_test.cmake
@@ -1,5 +1,5 @@
 macro(RUN CMD)
-  message(STATUS "${CMD}")
+  message(STATUS "Running \"${CMD}\"")
   separate_arguments(CMD_LIST NATIVE_COMMAND ${CMD})
   execute_process(
     COMMAND
@@ -19,6 +19,26 @@ file(REMOVE_RECURSE ${BUILD_DIR})
 # Run the toolchain
 set(TOOLCHAIN_COMMAND "PATH=${INSTALLATION_DIR}/bin:$ENV{PATH} ${TOOLCHAIN_COMMAND}")
 run(${TOOLCHAIN_COMMAND} "")
+
+# Verify that all required output files are generated
+message(STATUS "Checking output files...")
+
+string(REPLACE "," ";" ASSERT_EXISTS "${ASSERT_EXISTS}")
+set(MISSING_FILES FALSE)
+
+foreach(FILE ${ASSERT_EXISTS})
+  file(RELATIVE_PATH FNAME ${BUILD_DIR} ${FILE})
+  if(NOT EXISTS "${FILE}")
+    message(STATUS "[X] '${FNAME}'")
+    set(MISSING_FILES TRUE)
+  else()
+    message(STATUS "[V] '${FNAME}'")
+  endif()
+endforeach()
+
+if(MISSING_FILES)
+  message(FATAL_ERROR "Some output files are missing!")
+endif()
 
 # Assert usage and timing if any
 set(PYTHONPATH ${SYMBIFLOW_DIR}/utils)

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -523,43 +523,43 @@ rm -f $SOURCE/f_list_temp $SOURCE/v_list_tmp $SOURCE/v_list
 ##### Make file Targets #####
 if [ $1 == "-synth" ]; then
   echo -e "Performing Synthesis "
-  cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.eblif || cat $LOG_FILE && exit
+  cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.eblif || (cat $LOG_FILE && exit)
 elif [[ ! -z "$OUT" && $1 == "-compile" ]];then
 	if [[ " ${OUT_ARR[@]} " =~ " post_verilog " ]];then
-		cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.post_v || cat $LOG_FILE && exit
+		cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.post_v || (cat $LOG_FILE && exit)
 	fi
 
     if [ "$DEVICE" == "ql-eos-s3" ]; then
       if [[ " ${OUT_ARR[@]} " =~ " jlink " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.jlink || cat $LOG_FILE && exit
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.jlink || (cat $LOG_FILE && exit)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " openocd " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.openocd || cat $LOG_FILE && exit
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.openocd || (cat $LOG_FILE && exit)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " post_verilog " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow  ${BUILDDIR}/${TOP}.bit.v || cat $LOG_FILE && exit
+       cd $SOURCE;make -f Makefile.symbiflow  ${BUILDDIR}/${TOP}.bit.v || (cat $LOG_FILE && exit)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " header " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}_bit.h || cat $LOG_FILE && exit
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}_bit.h || (cat $LOG_FILE && exit)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " binary " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bin || cat $LOG_FILE && exit
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bit || (cat $LOG_FILE && exit)
       fi
     fi
 
     if [ "$DEVICE" == "ql-pp3" ]; then
       if [[ " ${OUT_ARR[@]} " =~ " post_verilog " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow  ${BUILDDIR}/${TOP}.bit.v || cat $LOG_FILE && exit
+       cd $SOURCE;make -f Makefile.symbiflow  ${BUILDDIR}/${TOP}.bit.v || (cat $LOG_FILE && exit)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " binary " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bin || cat $LOG_FILE && exit
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bit || (cat $LOG_FILE && exit)
       fi
     fi
 
 else
   if [ $1 == "-compile" ]; then
   echo -e "Running Synth->Pack->Place->Route->FASM->bitstream"
-    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.${RUN_TILL} || cat $LOG_FILE && exit
+    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.${RUN_TILL} || (cat $LOG_FILE && exit)
   fi
 fi
 

--- a/quicklogic/common/toolchain_wrappers/symbiflow_fasm2bels
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_fasm2bels
@@ -67,7 +67,7 @@ if [[ "$DEVICE" =~ ^(ql-eos-s3|ql-pp3|ql-pp3e)$ ]]; then
     fi
 
     echo "Running fasm2bels"
-    python3 ${FASM2BELS} ${BIT} --phy-db ${VPR_DB} --device-name ${FASM2BELS_DEVICE} --package-name ${PART} --input-type bitstream --output-verilog ../${VERILOG_FILE} ${PCF_ARGS} --output-pcf ../${PCF_FILE} --output-qcf ../${QCF_FILE}
+    python3 ${FASM2BELS} ${BIT} --phy-db ${VPR_DB} --device-name ${FASM2BELS_DEVICE} --package-name ${PART} --input-type bitstream --output-verilog ${VERILOG_FILE} ${PCF_ARGS} --output-pcf ${PCF_FILE} --output-qcf ${QCF_FILE}
 
 else
 

--- a/quicklogic/pp3/tests/features/install_test/counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/install_test/counter/CMakeLists.txt
@@ -7,6 +7,12 @@ add_binary_toolchain_test(
 
     ASSERT_USAGE  PB-CLOCK=0,PB-GMUX=0,PB-BIDIR=5
     ASSERT_TIMING fmax>=30.0
+
+    ASSERT_EXISTS
+        "top_post_synthesis.v"
+        "top_post_synthesis.sdf"
+        "top.bit.v"
+        "top.bit.v.pcf"
 )
 
 add_binary_toolchain_test(
@@ -18,4 +24,10 @@ add_binary_toolchain_test(
 
     ASSERT_USAGE  PB-CLOCK=0,PB-GMUX=0,PB-BIDIR=5
     ASSERT_TIMING fmax>=30.0
+
+    ASSERT_EXISTS
+        "top_post_synthesis.v"
+        "top_post_synthesis.sdf"
+        "top.bit.v"
+        "top.bit.v.pcf"
 )

--- a/quicklogic/pp3/tests/features/install_test/counter_assp/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/install_test/counter_assp/CMakeLists.txt
@@ -3,6 +3,13 @@ add_binary_toolchain_test(
     DEVICE    ql-eos-s3
     PINMAP    PD64
     PCF       chandalar.pcf
+    EXTRA_ARGS "-dump post_verilog"
 
     ASSERT_USAGE PB-ASSP=1,PB-GMUX=1
+
+    ASSERT_EXISTS
+        "top_post_synthesis.v"
+        "top_post_synthesis.sdf"
+        "top.bit.v"
+        "top.bit.v.pcf"
 )

--- a/quicklogic/pp3/tests/features/install_test/counter_gclk/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/install_test/counter_gclk/CMakeLists.txt
@@ -3,9 +3,16 @@ add_binary_toolchain_test(
     DEVICE    ql-eos-s3
     PINMAP    PD64
     PCF       chandalar.pcf
+    EXTRA_ARGS "-dump post_verilog"
 
     ASSERT_USAGE  PB-CLOCK=1,PB-GMUX=1,PB-BIDIR=4
     ASSERT_TIMING fmax>110.0
+
+    ASSERT_EXISTS
+        "top_post_synthesis.v"
+        "top_post_synthesis.sdf"
+        "top.bit.v"
+        "top.bit.v.pcf"
 )
 
 add_binary_toolchain_test(
@@ -13,7 +20,14 @@ add_binary_toolchain_test(
     DEVICE    ql-pp3
     PINMAP    WD30
     PCF       jimbob4.pcf
+    EXTRA_ARGS "-dump post_verilog"
 
     ASSERT_USAGE  PB-CLOCK=1,PB-GMUX=1,PB-BIDIR=4
     ASSERT_TIMING fmax>110.0
+
+    ASSERT_EXISTS
+        "top_post_synthesis.v"
+        "top_post_synthesis.sdf"
+        "top.bit.v"
+        "top.bit.v.pcf"
 )


### PR DESCRIPTION
Fixed errors in the `ql_symbiflow` wrapper script so that it correctly triggers bitstream generation.