### PR TITLE
Disable PP3 bin2seven test

### DIFF
--- a/quicklogic/pp3/tests/design_flow/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/CMakeLists.txt
@@ -2,7 +2,7 @@ set(QL_DESIGNS_DIR ../../../../designs)
 
 add_subdirectory(adder_8)
 add_subdirectory(bin2bcd)
-add_subdirectory(bin2seven)
+#add_subdirectory(bin2seven) # Causes ABC9 segfault: https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/590
 add_subdirectory(clock_tree_design)
 add_subdirectory(counter_8bit)
 add_subdirectory(counter_32bit)


### PR DESCRIPTION
This PR disables the bin2seven test design target for PP3 to temporarly fix the issue https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/590