### PR TITLE
Fix J-Link and OpenOCD scripts generation

### DIFF
--- a/quicklogic/common/cmake/quicklogic_jlink.cmake
+++ b/quicklogic/common/cmake/quicklogic_jlink.cmake
@@ -66,23 +66,14 @@ function(ADD_JLINK_OUTPUT)
   add_file_target(FILE ${WORK_DIR_REL}/${IOMUX_CONFIG} GENERATED)
 
   # Convert the binary bitstream to a JLINK script
-  set(BIT_AS_JLINK "top.bit.jlink")
-
-  add_custom_command(
-    OUTPUT ${WORK_DIR}/${BIT_AS_JLINK}
-    COMMAND ${PYTHON3} -m quicklogic_fasm.bitstream_to_jlink ${BITSTREAM_LOC} ${WORK_DIR}/${BIT_AS_JLINK}
-    DEPENDS ${BITSTREAM}
-  )
-
-  add_file_target(FILE ${WORK_DIR_REL}/${BIT_AS_JLINK} GENERATED)
-
-  # Concatenate th bitstream JLink script and the IOMUX config JLink script
   set(OUT_JLINK "top.jlink")
   add_custom_command(
     OUTPUT ${WORK_DIR}/${OUT_JLINK}
-    COMMAND cat ${WORK_DIR}/${BIT_AS_JLINK} ${WORK_DIR}/${IOMUX_CONFIG} >${WORK_DIR}/${OUT_JLINK}
-    DEPENDS ${WORK_DIR}/${BIT_AS_JLINK} ${WORK_DIR}/${IOMUX_CONFIG}
+    COMMAND ${PYTHON3} -m quicklogic_fasm.bitstream_to_jlink ${BITSTREAM_LOC} ${WORK_DIR}/${OUT_JLINK}
+    DEPENDS ${BITSTREAM} ${WORK_DIR}/${IOMUX_CONFIG}
   )
+
+  add_file_target(FILE ${WORK_DIR_REL}/${OUT_JLINK} GENERATED)
 
   add_custom_target(${PARENT}_jlink DEPENDS ${WORK_DIR}/${OUT_JLINK})
 

--- a/quicklogic/common/cmake/quicklogic_jlink.cmake
+++ b/quicklogic/common/cmake/quicklogic_jlink.cmake
@@ -104,4 +104,15 @@ function(ADD_JLINK_OUTPUT)
 
   add_custom_target(${PARENT}_jlink_hardware DEPENDS ${PARENT}_jlink_copy ${WORK_DIR}/${OUT_JLINK_HARDWARE})
 
+  set(VERIFY_SCRIPT ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/pp3/utils/verify_jlink_openocd.sh)
+  set(DUPLICATES_JLINK "duplicates.jlink")
+  add_custom_command(
+    OUTPUT ${WORK_DIR}/${DUPLICATES_JLINK}
+    COMMAND ${VERIFY_SCRIPT} ${WORK_DIR}/${OUT_JLINK} ${WORK_DIR}/${DUPLICATES_JLINK}
+    DEPENDS ${WORK_DIR}/${OUT_JLINK}
+  )
+
+  add_file_target(FILE ${WORK_DIR_REL}/${DUPLICATES_JLINK} GENERATED)
+  add_custom_target(${PARENT}_jlink_test DEPENDS ${WORK_DIR}/${DUPLICATES_JLINK})
+
 endfunction()

--- a/quicklogic/common/cmake/quicklogic_openocd.cmake
+++ b/quicklogic/common/cmake/quicklogic_openocd.cmake
@@ -66,23 +66,15 @@ function(ADD_OPENOCD_OUTPUT)
   add_file_target(FILE ${WORK_DIR_REL}/${IOMUX_CONFIG} GENERATED)
 
   # Convert the binary bitstream to a OpenOCD script
-  set(BIT_AS_OPENOCD "top.bit.openocd")
-
-  add_custom_command(
-    OUTPUT ${WORK_DIR}/${BIT_AS_OPENOCD}
-    COMMAND ${PYTHON3} -m quicklogic_fasm.bitstream_to_openocd ${BITSTREAM_LOC} ${WORK_DIR}/${BIT_AS_OPENOCD}
-    DEPENDS ${BITSTREAM}
-  )
-
-  add_file_target(FILE ${WORK_DIR_REL}/${BIT_AS_OPENOCD} GENERATED)
-
-  # Concatenate the bitstream OpenOCD script and the IOMUX config OpenOCD script
   set(OUT_OPENOCD "top.openocd")
+
   add_custom_command(
     OUTPUT ${WORK_DIR}/${OUT_OPENOCD}
-    COMMAND head -n -1 ${WORK_DIR}/${BIT_AS_OPENOCD} > ${WORK_DIR}/${OUT_OPENOCD} && cat ${WORK_DIR}/${IOMUX_CONFIG} >> ${WORK_DIR}/${OUT_OPENOCD} && echo '}' >> ${WORK_DIR}/${OUT_OPENOCD}
-    DEPENDS ${WORK_DIR}/${BIT_AS_OPENOCD} ${WORK_DIR}/${IOMUX_CONFIG}
+    COMMAND ${PYTHON3} -m quicklogic_fasm.bitstream_to_openocd ${BITSTREAM_LOC} ${WORK_DIR}/${OUT_OPENOCD}
+    DEPENDS ${BITSTREAM} ${WORK_DIR}/${IOMUX_CONFIG}
   )
+
+  add_file_target(FILE ${WORK_DIR_REL}/${OUT_OPENOCD} GENERATED)
 
   add_custom_target(${PARENT}_openocd DEPENDS ${WORK_DIR}/${OUT_OPENOCD})
 

--- a/quicklogic/common/cmake/quicklogic_openocd.cmake
+++ b/quicklogic/common/cmake/quicklogic_openocd.cmake
@@ -78,4 +78,15 @@ function(ADD_OPENOCD_OUTPUT)
 
   add_custom_target(${PARENT}_openocd DEPENDS ${WORK_DIR}/${OUT_OPENOCD})
 
+  set(VERIFY_SCRIPT ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/pp3/utils/verify_jlink_openocd.sh)
+  set(DUPLICATES_OPENOCD "duplicates.openocd")
+  add_custom_command(
+	  OUTPUT ${WORK_DIR}/${DUPLICATES_OPENOCD}
+	  COMMAND ${VERIFY_SCRIPT} ${WORK_DIR}/${OUT_OPENOCD} ${WORK_DIR}/${DUPLICATES_OPENOCD}
+	  DEPENDS ${WORK_DIR}/${OUT_OPENOCD}
+  )
+
+  add_file_target(FILE ${WORK_DIR_REL}/${DUPLICATES_OPENOCD} GENERATED)
+  add_custom_target(${PARENT}_openocd_test DEPENDS ${WORK_DIR}/${DUPLICATES_OPENOCD})
+
 endfunction()

--- a/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
@@ -69,8 +69,6 @@ add_jlink_output(
 
  add_dependencies(all_ql_tests btn_counter-ql-jimbob4_route)
  #add_dependencies(all_ql_tests btn_counter-ql-jimbob4_bit)
- #add_dependencies(all_ql_tests btn_counter-ql-jimbob4_jlink)
- #add_dependencies(all_ql_tests btn_counter-ql-jimbob4_openocd)
 
  add_fpga_target(
   NAME btn_counter-ql-jimbob4-pp3

--- a/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
@@ -22,12 +22,16 @@ add_openocd_output(
 
 add_dependencies(all_quick_tests btn_counter-ql-chandalar_bit)
 add_dependencies(all_quick_tests btn_counter-ql-chandalar_jlink)
+add_dependencies(all_quick_tests btn_counter-ql-chandalar_jlink_test)
 add_dependencies(all_quick_tests btn_counter-ql-chandalar_openocd)
+add_dependencies(all_quick_tests btn_counter-ql-chandalar_openocd_test)
 
 add_dependencies(all_ql_tests_bit btn_counter-ql-chandalar_bit)
 add_dependencies(all_ql_tests_bit_v btn_counter-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_jlink)
+add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_jlink_test)
 add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_openocd_test)
 
 
 add_fpga_target(
@@ -49,7 +53,9 @@ add_openocd_output(
 add_dependencies(all_ql_tests_bit btn_counter-ql-quickfeather_bit)
 add_dependencies(all_ql_tests_bit_v btn_counter-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_jlink)
+add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_jlink_test)
 add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_openocd_test)
 
 add_fpga_target(
   NAME btn_counter-ql-jimbob4

--- a/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
@@ -44,13 +44,8 @@ add_openocd_output(
 )
 
 add_dependencies(all_quick_tests btn_ff-ql-jimbob4_bit)
-add_dependencies(all_quick_tests btn_ff-ql-jimbob4_jlink)
-add_dependencies(all_quick_tests btn_ff-ql-jimbob4_openocd)
-
 add_dependencies(all_ql_tests_bit btn_ff-ql-jimbob4_bit)
 #add_dependencies(all_ql_tests_bit_v btn_ff-ql-jimbob4_bit_v)	# Failure in mux expanding
-add_dependencies(all_ql_tests_prog btn_ff-ql-jimbob4_jlink)
-add_dependencies(all_ql_tests_prog btn_ff-ql-jimbob4_openocd)
 
 add_fpga_target(
   NAME btn_ff-ql-jimbob4-pp3
@@ -69,10 +64,5 @@ add_openocd_output(
 )
 
 add_dependencies(all_quick_tests btn_ff-ql-jimbob4-pp3_bit)
-add_dependencies(all_quick_tests btn_ff-ql-jimbob4-pp3_jlink)
-add_dependencies(all_quick_tests btn_ff-ql-jimbob4-pp3_openocd)
-
 add_dependencies(all_ql_tests_bit btn_ff-ql-jimbob4-pp3_bit)
 add_dependencies(all_ql_tests_bit_v btn_ff-ql-jimbob4-pp3_bit_v)
-add_dependencies(all_ql_tests_prog btn_ff-ql-jimbob4-pp3_jlink)
-add_dependencies(all_ql_tests_prog btn_ff-ql-jimbob4-pp3_openocd)

--- a/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
@@ -21,11 +21,15 @@ add_openocd_output(
 add_dependencies(all_quick_tests btn_ff-ql-chandalar_bit)
 add_dependencies(all_quick_tests btn_ff-ql-chandalar_jlink)
 add_dependencies(all_quick_tests btn_ff-ql-chandalar_openocd)
+add_dependencies(all_quick_tests btn_ff-ql-chandalar_jlink_test)
+add_dependencies(all_quick_tests btn_ff-ql-chandalar_openocd_test)
 
 add_dependencies(all_ql_tests_bit btn_ff-ql-chandalar_bit)
 add_dependencies(all_ql_tests_bit_v btn_ff-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_jlink_test)
+add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_openocd_test)
 
 add_fpga_target(
   NAME btn_ff-ql-jimbob4

--- a/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
@@ -21,11 +21,15 @@ add_openocd_output(
 add_dependencies(all_quick_tests btn_xor-ql-chandalar_bit)
 add_dependencies(all_quick_tests btn_xor-ql-chandalar_jlink)
 add_dependencies(all_quick_tests btn_xor-ql-chandalar_openocd)
+add_dependencies(all_quick_tests btn_xor-ql-chandalar_jlink_test)
+add_dependencies(all_quick_tests btn_xor-ql-chandalar_openocd_test)
 
 add_dependencies(all_ql_tests_bit btn_xor-ql-chandalar_bit)
 add_dependencies(all_ql_tests_bit_v btn_xor-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_jlink_test)
+add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_openocd_test)
 
 add_fpga_target(
   NAME btn_xor-ql-jimbob4

--- a/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
@@ -44,13 +44,9 @@ add_openocd_output(
 )
 
 add_dependencies(all_quick_tests btn_xor-ql-jimbob4_bit)
-add_dependencies(all_quick_tests btn_xor-ql-jimbob4_jlink)
-add_dependencies(all_quick_tests btn_xor-ql-jimbob4_openocd)
 
 add_dependencies(all_ql_tests_bit btn_xor-ql-jimbob4_bit)
 #add_dependencies(all_ql_tests_bit_v btn_xor-ql-jimbob4_bit_v)	# Failure in mux expanding
-add_dependencies(all_ql_tests_prog btn_xor-ql-jimbob4_jlink)
-add_dependencies(all_ql_tests_prog btn_xor-ql-jimbob4_openocd)
 
 add_fpga_target(
   NAME btn_xor-ql-jimbob4-pp3
@@ -69,11 +65,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_quick_tests btn_xor-ql-jimbob4-pp3_bit)
-add_dependencies(all_quick_tests btn_xor-ql-jimbob4-pp3_jlink)
-add_dependencies(all_quick_tests btn_xor-ql-jimbob4-pp3_openocd)
 
 add_dependencies(all_ql_tests_bit btn_xor-ql-jimbob4-pp3_bit)
 add_dependencies(all_ql_tests_bit_v btn_xor-ql-jimbob4-pp3_bit_v)
-add_dependencies(all_ql_tests_prog btn_xor-ql-jimbob4-pp3_jlink)
-add_dependencies(all_ql_tests_prog btn_xor-ql-jimbob4-pp3_openocd)
 

--- a/quicklogic/pp3/tests/counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/counter/CMakeLists.txt
@@ -22,11 +22,15 @@ add_openocd_output(
 add_dependencies(all_quick_tests counter-ql-chandalar_bit)
 add_dependencies(all_quick_tests counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests counter-ql-chandalar_openocd)
+add_dependencies(all_quick_tests counter-ql-chandalar_jlink_test)
+add_dependencies(all_quick_tests counter-ql-chandalar_openocd_test)
 
 add_dependencies(all_ql_tests_bit counter-ql-chandalar_bit)
 add_dependencies(all_ql_tests_bit_v counter-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog counter-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog counter-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_prog counter-ql-chandalar_jlink_test)
+add_dependencies(all_ql_tests_prog counter-ql-chandalar_openocd_test)
 
 
 add_fpga_target(
@@ -50,3 +54,5 @@ add_dependencies(all_ql_tests_bit counter-ql-quickfeather_bit)
 add_dependencies(all_ql_tests_bit_v counter-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog counter-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog counter-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_prog counter-ql-quickfeather_jlink_test)
+add_dependencies(all_ql_tests_prog counter-ql-quickfeather_openocd_test)

--- a/quicklogic/pp3/tests/design_flow/bin2seven/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/bin2seven/CMakeLists.txt
@@ -44,8 +44,6 @@ add_dependencies(all_ql_tests_prog bin2seven-ql-chandalar_openocd)
 
 #add_dependencies(all_ql_tests_bit  bin2seven-ql-jimbob4_bit)
 #add_dependencies(all_ql_tests_bit_v bin2seven-ql-jimbob4_bit_v)
-#add_dependencies(all_ql_tests_prog bin2seven-ql-jimbob4_jlink)
-#add_dependencies(all_ql_tests_prog bin2seven-ql-jimbob4_openocd)
 
 add_fpga_target(
   NAME bin2seven-ql-jimbob4-pp3
@@ -65,5 +63,3 @@ add_openocd_output(
 
 add_dependencies(all_ql_tests_bit  bin2seven-ql-jimbob4-pp3_bit)
 #add_dependencies(all_ql_tests_bit_v bin2seven-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
-add_dependencies(all_ql_tests_prog bin2seven-ql-jimbob4-pp3_jlink)
-add_dependencies(all_ql_tests_prog bin2seven-ql-jimbob4-pp3_openocd)

--- a/quicklogic/pp3/tests/design_flow/counter_8bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/counter_8bit/CMakeLists.txt
@@ -46,8 +46,6 @@ add_dependencies(all_ql_tests_prog counter_8bit-ql-chandalar_openocd)
 
 #add_dependencies(all_ql_tests_bit  counter_8bit-ql-jimbob4_bit)
 #add_dependencies(all_ql_tests_bit_v counter_8bit-ql-jimbob4_bit_v)
-#add_dependencies(all_ql_tests_prog counter_8bit-ql-jimbob4_jlink)
-#add_dependencies(all_ql_tests_prog counter_8bit-ql-jimbob4_openocd)
 
 add_fpga_target(
   NAME counter_8bit-ql-jimbob4-pp3
@@ -68,6 +66,4 @@ add_openocd_output(
 
 add_dependencies(all_ql_tests_bit  counter_8bit-ql-jimbob4-pp3_bit)
 add_dependencies(all_ql_tests_bit_v counter_8bit-ql-jimbob4-pp3_bit_v)
-add_dependencies(all_ql_tests_prog counter_8bit-ql-jimbob4-pp3_jlink)
-add_dependencies(all_ql_tests_prog counter_8bit-ql-jimbob4-pp3_openocd)
 

--- a/quicklogic/pp3/tests/design_flow/test_logic_cell/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/test_logic_cell/CMakeLists.txt
@@ -46,8 +46,6 @@ add_dependencies(all_ql_tests_prog test_logic_cell-ql-chandalar_openocd)
 
 #add_dependencies(all_ql_tests_bit  test_logic_cell-ql-jimbob4_bit)
 #add_dependencies(all_ql_tests_bit_v test_logic_cell-ql-jimbob4_bit_v)
-#add_dependencies(all_ql_tests_prog test_logic_cell-ql-jimbob4_jlink)
-#add_dependencies(all_ql_tests_prog test_logic_cell-ql-jimbob4_openocd)
 
 add_fpga_target(
   NAME test_logic_cell-ql-jimbob4-pp3
@@ -68,5 +66,3 @@ add_openocd_output(
 
 add_dependencies(all_ql_tests_bit  test_logic_cell-ql-jimbob4-pp3_bit)
 add_dependencies(all_ql_tests_bit_v test_logic_cell-ql-jimbob4-pp3_bit_v)
-add_dependencies(all_ql_tests_prog test_logic_cell-ql-jimbob4-pp3_jlink)
-add_dependencies(all_ql_tests_prog test_logic_cell-ql-jimbob4-pp3_openocd)

--- a/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
@@ -69,13 +69,9 @@ add_openocd_output(
 )
 
 add_dependencies(all_quick_tests ext_counter-ql-jimbob4_bit)
-add_dependencies(all_quick_tests ext_counter-ql-jimbob4_jlink)
-add_dependencies(all_quick_tests ext_counter-ql-jimbob4_openocd)
 
 add_dependencies(all_ql_tests_bit ext_counter-ql-jimbob4_bit)
 #add_dependencies(all_ql_tests_bit_v ext_counter-ql-jimbob4_bit_v)	# Failure in mux expanding
-add_dependencies(all_ql_tests_prog ext_counter-ql-jimbob4_jlink)
-add_dependencies(all_ql_tests_prog ext_counter-ql-jimbob4_openocd)
 
 
 add_fpga_target(
@@ -95,10 +91,6 @@ add_openocd_output(
 )
 
 add_dependencies(all_quick_tests ext_counter-ql-jimbob4-pp3_bit)
-add_dependencies(all_quick_tests ext_counter-ql-jimbob4-pp3_jlink)
-add_dependencies(all_quick_tests ext_counter-ql-jimbob4-pp3_openocd)
 
 add_dependencies(all_ql_tests_bit ext_counter-ql-jimbob4-pp3_bit)
 add_dependencies(all_ql_tests_bit_v ext_counter-ql-jimbob4-pp3_bit_v)
-add_dependencies(all_ql_tests_prog ext_counter-ql-jimbob4-pp3_jlink)
-add_dependencies(all_ql_tests_prog ext_counter-ql-jimbob4-pp3_openocd)

--- a/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
@@ -21,11 +21,15 @@ add_openocd_output(
 add_dependencies(all_quick_tests ext_counter-ql-chandalar_bit)
 add_dependencies(all_quick_tests ext_counter-ql-chandalar_jlink)
 add_dependencies(all_quick_tests ext_counter-ql-chandalar_openocd)
+add_dependencies(all_quick_tests ext_counter-ql-chandalar_jlink_test)
+add_dependencies(all_quick_tests ext_counter-ql-chandalar_openocd_test)
 
 add_dependencies(all_ql_tests_bit ext_counter-ql-chandalar_bit)
 add_dependencies(all_ql_tests_bit_v ext_counter-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_jlink_test)
+add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_openocd_test)
 
 
 add_file_target(FILE quickfeather.pcf)
@@ -50,6 +54,8 @@ add_dependencies(all_ql_tests_bit ext_counter-ql-quickfeather_bit)
 add_dependencies(all_ql_tests_bit_v ext_counter-ql-quickfeather_bit_v)
 add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_jlink)
 add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_openocd)
+add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_jlink_test)
+add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_openocd_test)
 
 
 add_fpga_target(

--- a/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
@@ -44,13 +44,9 @@ add_openocd_output(
 )
 
 add_dependencies(all_quick_tests sdiomux_xor-ql-jimbob4_bit)
-add_dependencies(all_quick_tests sdiomux_xor-ql-jimbob4_jlink)
-add_dependencies(all_quick_tests sdiomux_xor-ql-jimbob4_openocd)
 
 add_dependencies(all_ql_tests_bit sdiomux_xor-ql-jimbob4_bit)
 #add_dependencies(all_ql_tests_bit_v sdiomux_xor-ql-jimbob4_bit_v)	# Failure in mux expanding
-add_dependencies(all_ql_tests_prog sdiomux_xor-ql-jimbob4_jlink)
-add_dependencies(all_ql_tests_prog sdiomux_xor-ql-jimbob4_openocd)
 
 add_fpga_target(
   NAME sdiomux_xor-ql-jimbob4-pp3
@@ -69,11 +65,7 @@ add_openocd_output(
 )
 
 add_dependencies(all_quick_tests sdiomux_xor-ql-jimbob4-pp3_bit)
-add_dependencies(all_quick_tests sdiomux_xor-ql-jimbob4-pp3_jlink)
-add_dependencies(all_quick_tests sdiomux_xor-ql-jimbob4-pp3_openocd)
 
 add_dependencies(all_ql_tests_bit sdiomux_xor-ql-jimbob4-pp3_bit)
 add_dependencies(all_ql_tests_bit_v sdiomux_xor-ql-jimbob4-pp3_bit_v)
-add_dependencies(all_ql_tests_prog sdiomux_xor-ql-jimbob4-pp3_jlink)
-add_dependencies(all_ql_tests_prog sdiomux_xor-ql-jimbob4-pp3_openocd)
 

--- a/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
@@ -21,11 +21,15 @@ add_openocd_output(
 add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_bit)
 add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_jlink)
 add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_openocd)
+add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_jlink_test)
+add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_openocd_test)
 
 add_dependencies(all_ql_tests_bit sdiomux_xor-ql-chandalar_bit)
 add_dependencies(all_ql_tests_bit_v sdiomux_xor-ql-chandalar_bit_v)
 add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_jlink)
 add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_openocd)
+add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_jlink_test)
+add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_openocd_test)
 
 add_fpga_target(
   NAME sdiomux_xor-ql-jimbob4

--- a/quicklogic/pp3/utils/verify_jlink_openocd.sh
+++ b/quicklogic/pp3/utils/verify_jlink_openocd.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# look for duplicated configuration cript footer,
+# exit with 1 if duplicate found (bad script format)
+
+# $1 - jlink/openocd script
+# $2 - output file
+
+
+cat $1 | grep '0x40004d[0-9]\{2\}' |  awk '{print $2}' | sort | uniq -d > $2
+[ -s $2 ] && exit 1 || exit 0


### PR DESCRIPTION
This PR fixes openocd and jlink scripts generation for EOS-S3 IOMUX configuration (removed unnecessary additional concatenation of bitstream and IOMUX config).