### PR TITLE
Split CI into multiple parallel jobs

### DIFF
--- a/.github/workflows/quicklogic.yml
+++ b/.github/workflows/quicklogic.yml
@@ -159,6 +159,7 @@ jobs:
 
           echo "PATH=${PATH}" >> $GITHUB_ENV
           echo "ROOT=${ROOT}" >> $GITHUB_ENV
+          echo "INSTALL_DIR=${INSTALL_DIR}" >> $GITHUB_ENV
 
       - name: Installation
         run: |

--- a/.github/workflows/quicklogic.yml
+++ b/.github/workflows/quicklogic.yml
@@ -131,6 +131,11 @@ jobs:
     needs: [code-quality, ci]
     steps:
 
+      - uses: actions/checkout@v2
+        with:
+          lfs: 'true'
+          submodules: true
+
       - name: Environment
         env:
           CI: 1

--- a/.github/workflows/quicklogic.yml
+++ b/.github/workflows/quicklogic.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Environment
         env:
-          CI: TEST
+          CI: 1
         run: |
           sudo rm -rf /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
           sudo apt update
@@ -45,8 +45,34 @@ jobs:
           ninja -j$(nproc) check_python
           ninja -j$(nproc) lint_python
 
+      - name: Python tests
+        run: |
+          cd ${ROOT}/build
+          source ../env/conda/bin/activate symbiflow_arch_def_base
+          ninja -j$(nproc) all_quicklogic_python_tests
+
   ci:
     runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+            - device: qlf_k4n8
+              family: qlf_k4n8
+
+            - device: qlf_k6n10
+              family: qlf_k6n10
+
+            - device: eos-s3
+              family: pp3
+
+            - device: pp3
+              family: pp3
+
+            - device: pp3e
+              family: pp3
+
     steps:
 
       - uses: actions/checkout@v2
@@ -56,7 +82,58 @@ jobs:
 
       - name: Environment
         env:
-          CI: TEST
+          CI: 1
+        run: |
+          sudo rm -rf /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+          sudo apt update
+          sudo apt install -y g++-8 gcc-8 colordiff coreutils graphviz inkscape make git git-lfs unzip cmake
+
+          mkdir .tmp
+          curl -L https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-linux.zip -o .tmp/ninja-linux.zip
+          unzip .tmp/ninja-linux.zip -d .tmp
+
+          export VPR_NUM_WORKERS=$(nproc)
+          export PATH=$PATH:$PWD/.tmp
+          export ROOT=$(pwd)
+          export INSTALL_DIR=quicklogic-arch-defs
+          export CMAKE_FLAGS="-GNinja -DINSTALL_FAMILIES=${{ matrix.family }} -DCMAKE_INSTALL_PREFIX=${ROOT}/${INSTALL_DIR}"
+
+          mkdir ${ROOT}/${INSTALL_DIR}
+          make env
+
+          echo "PATH=${PATH}" >> $GITHUB_ENV
+          echo "ROOT=${ROOT}" >> $GITHUB_ENV
+
+      - name: Tests
+        run: |
+          cd ${ROOT}/build
+          source ../env/conda/bin/activate symbiflow_arch_def_base
+          export DEVICE=all_${{ matrix.device }}_tests
+          ninja -j$(nproc) ${DEVICE/-/_}
+
+      - name: Installation
+        run: |
+          cd ${ROOT}/build
+          source ../env/conda/bin/activate symbiflow_arch_def_base
+          ninja install -j$(nproc)
+
+      - name: Toolchain tests
+        # FIXME: Re-enable toolchain tests for PP3e and qlf_k6n10 once they are added
+        if:  "matrix.device != 'pp3e' && matrix.device != 'qlf_k6n10'"
+        run: |
+          cd ${ROOT}/build
+          source ../env/conda/bin/activate symbiflow_arch_def_base
+          export CTEST_OUTPUT_ON_FAILURE=1
+          ctest --no-tests=error -R "quicklogic_toolchain_test_.*${{ matrix.device }}" -VV
+
+  packaging:
+    runs-on: ubuntu-18.04
+    needs: [code-quality, ci]
+    steps:
+
+      - name: Environment
+        env:
+          CI: 1
         run: |
           sudo rm -rf /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
           sudo apt update
@@ -75,29 +152,14 @@ jobs:
           mkdir ${ROOT}/${INSTALL_DIR}
           make env
 
-          echo "VPR_NUM_WORKERS=${VPR_NUM_WORKERS}" >> $GITHUB_ENV
           echo "PATH=${PATH}" >> $GITHUB_ENV
           echo "ROOT=${ROOT}" >> $GITHUB_ENV
-          echo "INSTALL_DIR=${INSTALL_DIR}" >> $GITHUB_ENV
-
-      - name: QuickLogic Tests
-        run: |
-          cd ${ROOT}/build
-          source ../env/conda/bin/activate symbiflow_arch_def_base
-          ninja -j$(nproc) all_quicklogic_tests
 
       - name: Installation
         run: |
           cd ${ROOT}/build
           source ../env/conda/bin/activate symbiflow_arch_def_base
           ninja install -j$(nproc)
-
-      - name: Toolchain tests
-        run: |
-          cd ${ROOT}/build
-          source ../env/conda/bin/activate symbiflow_arch_def_base
-          export CTEST_OUTPUT_ON_FAILURE=1
-          ctest --no-tests=error -R "quicklogic_toolchain_test_.*" -E "quicklogic_toolchain_test_.*_qlf_k6n10" -VV
 
       - name: Packaging
         run: |
@@ -113,7 +175,7 @@ jobs:
 
   upload-architectures:
     runs-on: ubuntu-18.04
-    needs: [code-quality, ci]
+    needs: [packaging]
     steps:
 
       - uses: actions/download-artifact@v2
@@ -138,7 +200,7 @@ jobs:
 
   upload-latest:
     runs-on: ubuntu-18.04
-    needs: [code-quality, ci, upload-architectures]
+    needs: [upload-architectures]
     steps:
 
       - uses: actions/download-artifact@v2

--- a/quicklogic/CMakeLists.txt
+++ b/quicklogic/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(QLF_FPGA_DATABASE_DIR ${symbiflow-arch-defs_SOURCE_DIR}/third_party/qlfpga-symbiflow-plugins)
 
+# Collective target for all Python tests
+add_custom_target(all_quicklogic_python_tests)
+add_dependencies(all_quicklogic_tests all_quicklogic_python_tests)
+
+
 add_subdirectory(common)
 
 add_subdirectory(qlf_k4n8)

--- a/quicklogic/common/cmake/quicklogic_jlink.cmake
+++ b/quicklogic/common/cmake/quicklogic_jlink.cmake
@@ -34,7 +34,9 @@ function(ADD_JLINK_OUTPUT)
   get_file_location(PCF_LOC ${PCF})
   get_target_property_required(BOARD ${PARENT} BOARD)
 
-  set(PINMAP ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/pp3/${BOARD}_pinmap.csv)
+  set(PINMAP ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/pp3/${BOARD}_pinmap.csv)
+  get_file_target(PINMAP_TARGET ${PINMAP})
+  get_file_location(PINMAP_LOC ${PINMAP})
 
   # Generate a JLINK script that sets IOMUX configuration.
   set(IOMUX_CONFIG_GEN ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/pp3/utils/eos_s3_iomux_config.py)
@@ -57,10 +59,10 @@ function(ADD_JLINK_OUTPUT)
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils:$PYTHONPATH
       ${PYTHON3} ${IOMUX_CONFIG_GEN}
         ${IOMUX_CONFIG_ARGS}
-        --map ${PINMAP}
+        --map ${PINMAP_LOC}
         --output-format jlink
         >${WORK_DIR}/${IOMUX_CONFIG}
-    DEPENDS ${IOMUX_CONFIG_GEN} ${IOMUX_CONFIG_DEPS}
+    DEPENDS ${IOMUX_CONFIG_GEN} ${IOMUX_CONFIG_DEPS} ${PINMAP_TARGET}
   )
 
   add_file_target(FILE ${WORK_DIR_REL}/${IOMUX_CONFIG} GENERATED)

--- a/quicklogic/common/cmake/quicklogic_openocd.cmake
+++ b/quicklogic/common/cmake/quicklogic_openocd.cmake
@@ -34,7 +34,9 @@ function(ADD_OPENOCD_OUTPUT)
   get_file_location(PCF_LOC ${PCF})
   get_target_property_required(BOARD ${PARENT} BOARD)
 
-  set(PINMAP ${symbiflow-arch-defs_BINARY_DIR}/quicklogic/pp3/${BOARD}_pinmap.csv)
+  set(PINMAP ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/pp3/${BOARD}_pinmap.csv)
+  get_file_target(PINMAP_TARGET ${PINMAP})
+  get_file_location(PINMAP_LOC ${PINMAP})
 
   # Generate a OpenOCD script that sets IOMUX configuration.
   set(IOMUX_CONFIG_GEN ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/pp3/utils/eos_s3_iomux_config.py)
@@ -57,10 +59,10 @@ function(ADD_OPENOCD_OUTPUT)
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils:$PYTHONPATH
       ${PYTHON3} ${IOMUX_CONFIG_GEN}
         ${IOMUX_CONFIG_ARGS}
-        --map ${PINMAP}
+        --map ${PINMAP_LOC}
         --output-format openocd
         >${WORK_DIR}/${IOMUX_CONFIG}
-    DEPENDS ${IOMUX_CONFIG_GEN} ${IOMUX_CONFIG_DEPS}
+    DEPENDS ${IOMUX_CONFIG_GEN} ${IOMUX_CONFIG_DEPS} ${PINMAP_TARGET}
   )
 
   add_file_target(FILE ${WORK_DIR_REL}/${IOMUX_CONFIG} GENERATED)

--- a/quicklogic/common/utils/CMakeLists.txt
+++ b/quicklogic/common/utils/CMakeLists.txt
@@ -1,7 +1,7 @@
 get_target_property_required(PYTHON3 env PYTHON3)
 
 # Add a target that runs tests for Python utils
-add_custom_target(all_python_tests
+add_custom_target(all_quicklogic_common_python_tests
     COMMAND
         ${CMAKE_COMMAND} -E env
         PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils:${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/common/utils:$PYTHONPATH
@@ -9,4 +9,4 @@ add_custom_target(all_python_tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_dependencies(all_quicklogic_tests all_python_tests)
+add_dependencies(all_quicklogic_python_tests all_quicklogic_common_python_tests)

--- a/quicklogic/pp3/tests/CMakeLists.txt
+++ b/quicklogic/pp3/tests/CMakeLists.txt
@@ -1,17 +1,40 @@
-add_custom_target(all_ql_tests_bit_v)
-add_custom_target(all_ql_tests_bit)
-add_custom_target(all_ql_tests_regression)
-add_custom_target(all_ql_tests_prog)
+# EOS-S3 test targets
+add_custom_target(all_eos_s3_tests)
 
-add_dependencies(all_ql_tests_prog all_ql_tests_bit)
+add_custom_target(all_eos_s3_tests_regression)
+add_custom_target(all_eos_s3_tests_bit)
+add_custom_target(all_eos_s3_tests_bit_v)
+add_custom_target(all_eos_s3_tests_prog)
 
-add_custom_target(all_ql_tests)
-add_dependencies(all_quicklogic_tests all_ql_tests)
-add_dependencies(all_ql_tests all_ql_tests_bit)
-add_dependencies(all_ql_tests all_ql_tests_bit_v)
-add_dependencies(all_ql_tests all_ql_tests_regression)
+add_dependencies(all_eos_s3_tests all_eos_s3_tests_regression)
+add_dependencies(all_eos_s3_tests all_eos_s3_tests_bit)
+add_dependencies(all_eos_s3_tests all_eos_s3_tests_bit_v)
+add_dependencies(all_eos_s3_tests all_eos_s3_tests_prog)
 
-add_custom_target(all_quick_tests)
+# PP3 test targets
+add_custom_target(all_pp3_tests)
+
+add_custom_target(all_pp3_tests_regression)
+add_custom_target(all_pp3_tests_bit)
+add_custom_target(all_pp3_tests_bit_v)
+
+add_dependencies(all_pp3_tests all_pp3_tests_regression)
+add_dependencies(all_pp3_tests all_pp3_tests_bit)
+add_dependencies(all_pp3_tests all_pp3_tests_bit_v)
+
+# PP3E test targets
+add_custom_target(all_pp3e_tests)
+
+add_custom_target(all_pp3e_tests_bit)
+
+add_dependencies(all_pp3e_tests all_pp3e_tests_bit)
+
+# Bind to the all QuickLogic tests target
+add_dependencies(all_quicklogic_tests all_eos_s3_tests)
+add_dependencies(all_quicklogic_tests all_pp3_tests)
+add_dependencies(all_quicklogic_tests all_pp3e_tests)
+
+# =============================================================================
 
 # Tests for packing and placing primitives. Not to be run on actual HW !
 add_subdirectory(wire)
@@ -32,5 +55,5 @@ add_subdirectory(ext_mult)
 
 # QuickLogic test suite
 add_subdirectory(design_flow)
-
+# Feature / regression tests
 add_subdirectory(features)

--- a/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
@@ -20,19 +20,10 @@ add_openocd_output(
   PARENT btn_counter-ql-chandalar
 )
 
-add_dependencies(all_quick_tests btn_counter-ql-chandalar_bit)
-add_dependencies(all_quick_tests btn_counter-ql-chandalar_jlink)
-add_dependencies(all_quick_tests btn_counter-ql-chandalar_jlink_test)
-add_dependencies(all_quick_tests btn_counter-ql-chandalar_openocd)
-add_dependencies(all_quick_tests btn_counter-ql-chandalar_openocd_test)
-
-add_dependencies(all_ql_tests_bit btn_counter-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v btn_counter-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_jlink_test)
-add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_openocd)
-add_dependencies(all_ql_tests_prog btn_counter-ql-chandalar_openocd_test)
-
+add_dependencies(all_eos_s3_tests_bit btn_counter-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v btn_counter-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog btn_counter-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog btn_counter-ql-chandalar_openocd)
 
 add_fpga_target(
   NAME btn_counter-ql-quickfeather
@@ -50,12 +41,10 @@ add_openocd_output(
   PARENT btn_counter-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests_bit btn_counter-ql-quickfeather_bit)
-add_dependencies(all_ql_tests_bit_v btn_counter-ql-quickfeather_bit_v)
-add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_jlink_test)
-add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_openocd)
-add_dependencies(all_ql_tests_prog btn_counter-ql-quickfeather_openocd_test)
+add_dependencies(all_eos_s3_tests_bit btn_counter-ql-quickfeather_bit)
+add_dependencies(all_eos_s3_tests_bit_v btn_counter-ql-quickfeather_bit_v)
+add_dependencies(all_eos_s3_tests_prog btn_counter-ql-quickfeather_jlink)
+add_dependencies(all_eos_s3_tests_prog btn_counter-ql-quickfeather_openocd)
 
 add_fpga_target(
   NAME btn_counter-ql-jimbob4
@@ -92,10 +81,9 @@ add_jlink_output(
   PARENT btn_counter-ql-jimbob4-pp3
 )
 
-add_dependencies(all_quick_tests btn_counter-ql-jimbob4-pp3_route)
 
-add_dependencies(all_ql_tests_bit btn_counter-ql-jimbob4-pp3_route)
-add_dependencies(all_ql_tests_bit_v btn_counter-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit btn_counter-ql-jimbob4-pp3_route)
+add_dependencies(all_pp3_tests_bit_v btn_counter-ql-jimbob4-pp3_bit)
 
 add_fpga_target(
   NAME btn_counter-ql-pd64
@@ -105,7 +93,6 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
 )
 
-add_dependencies(all_quick_tests btn_counter-ql-pd64_route)
-add_dependencies(all_ql_tests_bit btn_counter-ql-pd64_route)
-add_dependencies(all_ql_tests_bit_v btn_counter-ql-pd64_bit)
+add_dependencies(all_pp3_tests_bit btn_counter-ql-pd64_route)
+add_dependencies(all_pp3_tests_bit_v btn_counter-ql-pd64_bit)
 

--- a/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_counter/CMakeLists.txt
@@ -62,8 +62,8 @@ add_jlink_output(
   PARENT btn_counter-ql-jimbob4
 )
 
- add_dependencies(all_ql_tests btn_counter-ql-jimbob4_route)
- #add_dependencies(all_ql_tests btn_counter-ql-jimbob4_bit)
+ add_dependencies(all_pp3e_tests btn_counter-ql-jimbob4_route)
+ #add_dependencies(all_pp3e_tests btn_counter-ql-jimbob4_bit)
 
  add_fpga_target(
   NAME btn_counter-ql-jimbob4-pp3

--- a/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_ff/CMakeLists.txt
@@ -18,18 +18,10 @@ add_openocd_output(
   PARENT btn_ff-ql-chandalar
 )
 
-add_dependencies(all_quick_tests btn_ff-ql-chandalar_bit)
-add_dependencies(all_quick_tests btn_ff-ql-chandalar_jlink)
-add_dependencies(all_quick_tests btn_ff-ql-chandalar_openocd)
-add_dependencies(all_quick_tests btn_ff-ql-chandalar_jlink_test)
-add_dependencies(all_quick_tests btn_ff-ql-chandalar_openocd_test)
-
-add_dependencies(all_ql_tests_bit btn_ff-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v btn_ff-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_openocd)
-add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_jlink_test)
-add_dependencies(all_ql_tests_prog btn_ff-ql-chandalar_openocd_test)
+add_dependencies(all_eos_s3_tests_bit btn_ff-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v btn_ff-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog btn_ff-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog btn_ff-ql-chandalar_openocd)
 
 add_fpga_target(
   NAME btn_ff-ql-jimbob4
@@ -47,9 +39,8 @@ add_openocd_output(
   PARENT btn_ff-ql-jimbob4
 )
 
-add_dependencies(all_quick_tests btn_ff-ql-jimbob4_bit)
-add_dependencies(all_ql_tests_bit btn_ff-ql-jimbob4_bit)
-#add_dependencies(all_ql_tests_bit_v btn_ff-ql-jimbob4_bit_v)	# Failure in mux expanding
+add_dependencies(all_pp3e_tests_bit btn_ff-ql-jimbob4_bit)
+#add_dependencies(all_pp3e_tests_bit_v btn_ff-ql-jimbob4_bit_v)	# Failure in mux expanding
 
 add_fpga_target(
   NAME btn_ff-ql-jimbob4-pp3
@@ -67,6 +58,5 @@ add_openocd_output(
   PARENT btn_ff-ql-jimbob4-pp3
 )
 
-add_dependencies(all_quick_tests btn_ff-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit btn_ff-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v btn_ff-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit btn_ff-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v btn_ff-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/btn_xor/CMakeLists.txt
@@ -18,18 +18,10 @@ add_openocd_output(
   PARENT btn_xor-ql-chandalar
 )
 
-add_dependencies(all_quick_tests btn_xor-ql-chandalar_bit)
-add_dependencies(all_quick_tests btn_xor-ql-chandalar_jlink)
-add_dependencies(all_quick_tests btn_xor-ql-chandalar_openocd)
-add_dependencies(all_quick_tests btn_xor-ql-chandalar_jlink_test)
-add_dependencies(all_quick_tests btn_xor-ql-chandalar_openocd_test)
-
-add_dependencies(all_ql_tests_bit btn_xor-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v btn_xor-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_openocd)
-add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_jlink_test)
-add_dependencies(all_ql_tests_prog btn_xor-ql-chandalar_openocd_test)
+add_dependencies(all_eos_s3_tests_bit btn_xor-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v btn_xor-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog btn_xor-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog btn_xor-ql-chandalar_openocd)
 
 add_fpga_target(
   NAME btn_xor-ql-jimbob4
@@ -47,10 +39,8 @@ add_openocd_output(
   PARENT btn_xor-ql-jimbob4
 )
 
-add_dependencies(all_quick_tests btn_xor-ql-jimbob4_bit)
-
-add_dependencies(all_ql_tests_bit btn_xor-ql-jimbob4_bit)
-#add_dependencies(all_ql_tests_bit_v btn_xor-ql-jimbob4_bit_v)	# Failure in mux expanding
+add_dependencies(all_pp3e_tests_bit btn_xor-ql-jimbob4_bit)
+#add_dependencies(all_pp3e_tests_bit_v btn_xor-ql-jimbob4_bit_v)	# Failure in mux expanding
 
 add_fpga_target(
   NAME btn_xor-ql-jimbob4-pp3
@@ -68,8 +58,5 @@ add_openocd_output(
   PARENT btn_xor-ql-jimbob4-pp3
 )
 
-add_dependencies(all_quick_tests btn_xor-ql-jimbob4-pp3_bit)
-
-add_dependencies(all_ql_tests_bit btn_xor-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v btn_xor-ql-jimbob4-pp3_bit_v)
-
+add_dependencies(all_pp3_tests_bit btn_xor-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v btn_xor-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/consts/CMakeLists.txt
+++ b/quicklogic/pp3/tests/consts/CMakeLists.txt
@@ -10,8 +10,7 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_ql_tests consts-ql-chandalar_route)
-add_dependencies(all_quick_tests consts-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests consts-ql-chandalar_route)
 
 add_fpga_target(
   NAME consts-ql-jimbob4
@@ -29,7 +28,7 @@ add_jlink_output(
   PARENT consts-ql-jimbob4
 )
 
- add_dependencies(all_ql_tests consts-ql-jimbob4_route)
+ add_dependencies(all_pp3e_tests consts-ql-jimbob4_route)
 
  add_fpga_target(
   NAME consts-ql-jimbob4-pp3
@@ -47,5 +46,5 @@ add_jlink_output(
   PARENT consts-ql-jimbob4-pp3
 )
 
- add_dependencies(all_ql_tests consts-ql-jimbob4-pp3_route)
+ add_dependencies(all_pp3_tests consts-ql-jimbob4-pp3_route)
 

--- a/quicklogic/pp3/tests/counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/counter/CMakeLists.txt
@@ -19,19 +19,10 @@ add_openocd_output(
   PARENT counter-ql-chandalar
 )
 
-add_dependencies(all_quick_tests counter-ql-chandalar_bit)
-add_dependencies(all_quick_tests counter-ql-chandalar_jlink)
-add_dependencies(all_quick_tests counter-ql-chandalar_openocd)
-add_dependencies(all_quick_tests counter-ql-chandalar_jlink_test)
-add_dependencies(all_quick_tests counter-ql-chandalar_openocd_test)
-
-add_dependencies(all_ql_tests_bit counter-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v counter-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog counter-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog counter-ql-chandalar_openocd)
-add_dependencies(all_ql_tests_prog counter-ql-chandalar_jlink_test)
-add_dependencies(all_ql_tests_prog counter-ql-chandalar_openocd_test)
-
+add_dependencies(all_eos_s3_tests_bit counter-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v counter-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog counter-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog counter-ql-chandalar_openocd)
 
 add_fpga_target(
   NAME counter-ql-quickfeather
@@ -50,9 +41,7 @@ add_openocd_output(
   PARENT counter-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests_bit counter-ql-quickfeather_bit)
-add_dependencies(all_ql_tests_bit_v counter-ql-quickfeather_bit_v)
-add_dependencies(all_ql_tests_prog counter-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests_prog counter-ql-quickfeather_openocd)
-add_dependencies(all_ql_tests_prog counter-ql-quickfeather_jlink_test)
-add_dependencies(all_ql_tests_prog counter-ql-quickfeather_openocd_test)
+add_dependencies(all_eos_s3_tests_bit counter-ql-quickfeather_bit)
+add_dependencies(all_eos_s3_tests_bit_v counter-ql-quickfeather_bit_v)
+add_dependencies(all_eos_s3_tests_prog counter-ql-quickfeather_jlink)
+add_dependencies(all_eos_s3_tests_prog counter-ql-quickfeather_openocd)

--- a/quicklogic/pp3/tests/design_flow/IR_Remote/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/IR_Remote/CMakeLists.txt
@@ -20,7 +20,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=1,PB-GMUX=1,PB-LOGIC<=386
 )
 
-add_dependencies(all_ql_tests_bit   IR_Remote-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v IR_Remote-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
+add_dependencies(all_pp3_tests_bit   IR_Remote-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v IR_Remote-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
 
-add_dependencies(all_ql_tests_regression IR_Remote-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression IR_Remote-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/Simon_bit_serial_top_module/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/Simon_bit_serial_top_module/CMakeLists.txt
@@ -14,9 +14,9 @@ add_fpga_target(
   ASSERT_TIMING fmax>=20.0
 )
 
-add_dependencies(all_ql_tests_bit   Simon_bit_serial_top_module-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v Simon_bit_serial_top_module-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   Simon_bit_serial_top_module-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v Simon_bit_serial_top_module-ql-jimbob4-pp3_bit_v)
 
-add_dependencies(all_ql_tests_regression Simon_bit_serial_top_module-ql-jimbob4-pp3_assert_usage)
-add_dependencies(all_ql_tests_regression Simon_bit_serial_top_module-ql-jimbob4-pp3_assert_timing)
+add_dependencies(all_pp3_tests_regression Simon_bit_serial_top_module-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression Simon_bit_serial_top_module-ql-jimbob4-pp3_assert_timing)
 

--- a/quicklogic/pp3/tests/design_flow/adder_8/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/adder_8/CMakeLists.txt
@@ -15,8 +15,8 @@ add_fpga_target(
   ASSERT_TIMING fmax>=13.5
 )
 
-add_dependencies(all_ql_tests_bit   adder_8-ql-pd64_bit)
-add_dependencies(all_ql_tests_bit_v adder_8-ql-pd64_bit_v)
+add_dependencies(all_pp3_tests_bit   adder_8-ql-pd64_bit)
+add_dependencies(all_pp3_tests_bit_v adder_8-ql-pd64_bit_v)
 
-add_dependencies(all_ql_tests_regression adder_8-ql-pd64_assert_usage)
-add_dependencies(all_ql_tests_regression adder_8-ql-pd64_assert_timing)
+add_dependencies(all_pp3_tests_regression adder_8-ql-pd64_assert_usage)
+add_dependencies(all_pp3_tests_regression adder_8-ql-pd64_assert_timing)

--- a/quicklogic/pp3/tests/design_flow/bin2bcd/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/bin2bcd/CMakeLists.txt
@@ -12,8 +12,8 @@ add_fpga_target(
   ASSERT_TIMING fmax>=13.0
 )
 
-add_dependencies(all_ql_tests_bit   bin2bcd-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v bin2bcd-ql-jimbob4-pp3_bit_v) # FIXME: PCF file is required by the BIT_TO_V_CMD
+add_dependencies(all_pp3_tests_bit   bin2bcd-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v bin2bcd-ql-jimbob4-pp3_bit_v) # FIXME: PCF file is required by the BIT_TO_V_CMD
 
-add_dependencies(all_ql_tests_regression bin2bcd-ql-jimbob4-pp3_assert_usage)
-add_dependencies(all_ql_tests_regression bin2bcd-ql-jimbob4-pp3_assert_timing)
+add_dependencies(all_pp3_tests_regression bin2bcd-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression bin2bcd-ql-jimbob4-pp3_assert_timing)

--- a/quicklogic/pp3/tests/design_flow/bin2seven/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/bin2seven/CMakeLists.txt
@@ -20,10 +20,10 @@ add_openocd_output(
   PARENT bin2seven-ql-chandalar
 )
 
-add_dependencies(all_ql_tests_bit  bin2seven-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v bin2seven-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog bin2seven-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog bin2seven-ql-chandalar_openocd)
+add_dependencies(all_eos_s3_tests_bit  bin2seven-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v bin2seven-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog bin2seven-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog bin2seven-ql-chandalar_openocd)
 
 # FIXME: FasmInconsistentBits: feature X16Y16.LOGIC.LOGIC.Ipwr_gates.J_pwr_st
 #add_fpga_target(
@@ -42,8 +42,8 @@ add_dependencies(all_ql_tests_prog bin2seven-ql-chandalar_openocd)
   #PARENT bin2seven-ql-jimbob4
 #)
 
-#add_dependencies(all_ql_tests_bit  bin2seven-ql-jimbob4_bit)
-#add_dependencies(all_ql_tests_bit_v bin2seven-ql-jimbob4_bit_v)
+#add_dependencies(all_pp3e_tests_bit  bin2seven-ql-jimbob4_bit)
+#add_dependencies(all_pp3e_tests_bit_v bin2seven-ql-jimbob4_bit_v)
 
 add_fpga_target(
   NAME bin2seven-ql-jimbob4-pp3
@@ -61,5 +61,5 @@ add_openocd_output(
   PARENT bin2seven-ql-jimbob4-pp3
 )
 
-add_dependencies(all_ql_tests_bit  bin2seven-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v bin2seven-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
+add_dependencies(all_pp3_tests_bit  bin2seven-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v bin2seven-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)

--- a/quicklogic/pp3/tests/design_flow/camif/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/camif/CMakeLists.txt
@@ -23,11 +23,10 @@ add_openocd_output(
   PARENT camif-ql-chandalar
 )
 
-add_dependencies(all_ql_tests_bit  camif-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v camif-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog camif-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog camif-ql-chandalar_openocd)
-add_dependencies(all_quick_tests camif-ql-chandalar_analysis)
+add_dependencies(all_eos_s3_tests_bit  camif-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v camif-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog camif-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog camif-ql-chandalar_openocd)
 add_dependencies(camif-ql-chandalar_analysis camif-ql-chandalar_bit_v)
 
 add_fpga_target(
@@ -48,10 +47,7 @@ add_openocd_output(
   PARENT camif-ql-pd64
 )
 
-add_dependencies(all_ql_tests_bit  camif-ql-pd64_bit)
-add_dependencies(all_ql_tests_bit_v camif-ql-pd64_bit_v)
-add_dependencies(all_ql_tests_prog camif-ql-pd64_jlink)
-add_dependencies(all_ql_tests_prog camif-ql-pd64_openocd)
-add_dependencies(all_quick_tests camif-ql-pd64_analysis)
+add_dependencies(all_pp3_tests_bit  camif-ql-pd64_bit)
+add_dependencies(all_pp3_tests_bit_v camif-ql-pd64_bit_v)
 add_dependencies(camif-ql-pd64_analysis camif-ql-pd64_bit_v)
 

--- a/quicklogic/pp3/tests/design_flow/cavlc_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/cavlc_top/CMakeLists.txt
@@ -36,9 +36,9 @@ add_openocd_output(
 )
 
 # FIXME: Temporarily disable due to not enough resources after packing
-#add_dependencies(all_ql_tests cavlc-ql-chandalar_bit)
-#add_dependencies(all_ql_tests cavlc-ql-chandalar_jlink)
-#add_dependencies(all_ql_tests cavlc-ql-chandalar_openocd)
+#add_dependencies(all_eos_s3_tests cavlc-ql-chandalar_bit)
+#add_dependencies(all_eos_s3_tests cavlc-ql-chandalar_jlink)
+#add_dependencies(all_eos_s3_tests cavlc-ql-chandalar_openocd)
 
 
 add_fpga_target(
@@ -65,6 +65,6 @@ add_openocd_output(
 )
 
 # FIXME: Temporarily disable due to not enough resources after packing
-#add_dependencies(all_ql_tests cavlc-ql-pd64_bit)
-#add_dependencies(all_ql_tests cavlc-ql-pd64_jlink)
-#add_dependencies(all_ql_tests cavlc-ql-pd64_openocd)
+#add_dependencies(all_pp3_tests cavlc-ql-pd64_bit)
+#add_dependencies(all_pp3_tests cavlc-ql-pd64_jlink)
+#add_dependencies(all_pp3_tests cavlc-ql-pd64_openocd)

--- a/quicklogic/pp3/tests/design_flow/cf_fft_256_8/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/cf_fft_256_8/CMakeLists.txt
@@ -11,5 +11,5 @@ add_fpga_target(
   AUTO_ADD_FILE_TARGET
 )
 
-add_dependencies(all_ql_tests_bit   cf_fft_256_8-ql-pd64_bit)
-add_dependencies(all_ql_tests_bit_v cf_fft_256_8-ql-pd64_bit_v)
+add_dependencies(all_pp3_tests_bit   cf_fft_256_8-ql-pd64_bit)
+add_dependencies(all_pp3_tests_bit_v cf_fft_256_8-ql-pd64_bit_v)

--- a/quicklogic/pp3/tests/design_flow/clock_tree_design/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/clock_tree_design/CMakeLists.txt
@@ -13,7 +13,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=5,PB-GMUX=5,PB-LOGIC<=133
 )
 
-add_dependencies(all_ql_tests_bit   clock_tree_design-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v clock_tree_design-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   clock_tree_design-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v clock_tree_design-ql-jimbob4-pp3_bit_v)
 
-add_dependencies(all_ql_tests_regression clock_tree_design-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression clock_tree_design-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/counter_16bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/counter_16bit/CMakeLists.txt
@@ -13,8 +13,8 @@ add_fpga_target(
   ASSERT_TIMING fmax>=20.0
 )
 
-add_dependencies(all_ql_tests_bit   counter_16bit-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v counter_16bit-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   counter_16bit-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v counter_16bit-ql-jimbob4-pp3_bit_v)
 
-add_dependencies(all_ql_tests_regression counter_16bit-ql-jimbob4-pp3_assert_usage)
-add_dependencies(all_ql_tests_regression counter_16bit-ql-jimbob4-pp3_assert_timing)
+add_dependencies(all_pp3_tests_regression counter_16bit-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression counter_16bit-ql-jimbob4-pp3_assert_timing)

--- a/quicklogic/pp3/tests/design_flow/counter_32bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/counter_32bit/CMakeLists.txt
@@ -20,10 +20,10 @@ add_openocd_output(
   PARENT counter_32bit-ql-chandalar
 )
 
-add_dependencies(all_ql_tests_bit  counter_32bit-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v counter_32bit-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog counter_32bit-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog counter_32bit-ql-chandalar_openocd)
+add_dependencies(all_eos_s3_tests_bit  counter_32bit-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v counter_32bit-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog counter_32bit-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog counter_32bit-ql-chandalar_openocd)
 
 
 add_fpga_target(
@@ -43,8 +43,6 @@ add_openocd_output(
   PARENT counter_32bit-ql-pd64
 )
 
-add_dependencies(all_ql_tests_bit  counter_32bit-ql-pd64_bit)
-add_dependencies(all_ql_tests_bit_v counter_32bit-ql-pd64_bit_v)
-add_dependencies(all_ql_tests_prog counter_32bit-ql-pd64_jlink)
-add_dependencies(all_ql_tests_prog counter_32bit-ql-pd64_openocd)
+add_dependencies(all_pp3_tests_bit  counter_32bit-ql-pd64_bit)
+add_dependencies(all_pp3_tests_bit_v counter_32bit-ql-pd64_bit_v)
 

--- a/quicklogic/pp3/tests/design_flow/counter_8bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/counter_8bit/CMakeLists.txt
@@ -21,10 +21,10 @@ add_openocd_output(
   PARENT counter_8bit-ql-chandalar
 )
 
-add_dependencies(all_ql_tests_bit  counter_8bit-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v counter_8bit-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog counter_8bit-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog counter_8bit-ql-chandalar_openocd)
+add_dependencies(all_eos_s3_tests_bit  counter_8bit-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v counter_8bit-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog counter_8bit-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog counter_8bit-ql-chandalar_openocd)
 
 # FIXME: FasmInconsistentBits: feature X31Y34.INTERFACE.BIDIR.INV.OSEL
 #add_fpga_target(
@@ -44,8 +44,8 @@ add_dependencies(all_ql_tests_prog counter_8bit-ql-chandalar_openocd)
   #PARENT counter_8bit-ql-jimbob4
 #)
 
-#add_dependencies(all_ql_tests_bit  counter_8bit-ql-jimbob4_bit)
-#add_dependencies(all_ql_tests_bit_v counter_8bit-ql-jimbob4_bit_v)
+#add_dependencies(all_pp3e_tests_bit  counter_8bit-ql-jimbob4_bit)
+#add_dependencies(all_pp3e_tests_bit_v counter_8bit-ql-jimbob4_bit_v)
 
 add_fpga_target(
   NAME counter_8bit-ql-jimbob4-pp3
@@ -64,6 +64,5 @@ add_openocd_output(
   PARENT counter_8bit-ql-jimbob4-pp3
 )
 
-add_dependencies(all_ql_tests_bit  counter_8bit-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v counter_8bit-ql-jimbob4-pp3_bit_v)
-
+add_dependencies(all_pp3_tests_bit  counter_8bit-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v counter_8bit-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/design_flow/dct_mac/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/dct_mac/CMakeLists.txt
@@ -21,5 +21,5 @@ add_fpga_target(
 )
 
 # FIXME: design requires over 32GB of RAM for packing step
-#add_dependencies(all_ql_tests_bit   dct_mac-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v dct_mac-ql-jimbob4-pp3_bit_v)
+#add_dependencies(all_pp3_tests_bit   dct_mac-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v dct_mac-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/design_flow/e_sdio_host_controller/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/e_sdio_host_controller/CMakeLists.txt
@@ -29,7 +29,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=2,PB-GMUX=2,PB-LOGIC<=498
 )
 
-add_dependencies(all_ql_tests_bit   e_sdio_host_controller-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v e_sdio_host_controller-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
+add_dependencies(all_pp3_tests_bit   e_sdio_host_controller-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v e_sdio_host_controller-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
 
-add_dependencies(all_ql_tests_regression e_sdio_host_controller-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression e_sdio_host_controller-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/i2c_master_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/i2c_master_top/CMakeLists.txt
@@ -16,7 +16,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=2,PB-GMUX=2,PB-LOGIC<=160
 )
 
-add_dependencies(all_ql_tests_bit   i2c_master_top-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v i2c_master_top-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   i2c_master_top-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v i2c_master_top-ql-jimbob4-pp3_bit_v)
 
-add_dependencies(all_ql_tests_regression i2c_master_top-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression i2c_master_top-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/iir/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/iir/CMakeLists.txt
@@ -11,7 +11,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=2,PB-GMUX=2,PB-LOGIC<=878
 )
 
-add_dependencies(all_ql_tests_bit   iir-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v iir-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
+add_dependencies(all_pp3_tests_bit   iir-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v iir-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
 
-add_dependencies(all_ql_tests_regression iir-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression iir-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/jpeg_qnr/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/jpeg_qnr/CMakeLists.txt
@@ -15,8 +15,8 @@ add_fpga_target(
   ASSERT_TIMING fmax>=18.0
 )
 
-add_dependencies(all_ql_tests_bit   jpeg_qnr-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v jpeg_qnr-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
+add_dependencies(all_pp3_tests_bit   jpeg_qnr-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v jpeg_qnr-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
 
-add_dependencies(all_ql_tests_regression jpeg_qnr-ql-jimbob4-pp3_assert_usage)
-add_dependencies(all_ql_tests_regression jpeg_qnr-ql-jimbob4-pp3_assert_timing)
+add_dependencies(all_pp3_tests_regression jpeg_qnr-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression jpeg_qnr-ql-jimbob4-pp3_assert_timing)

--- a/quicklogic/pp3/tests/design_flow/multiplier_8bit/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/multiplier_8bit/CMakeLists.txt
@@ -11,7 +11,7 @@ add_fpga_target(
   ASSERT_USAGE PB-LOGIC<=105
 )
 
-add_dependencies(all_ql_tests_bit   multiplier_8bit-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v multiplier_8bit-ql-jimbob4-pp3_bit_v) # FIXME: PCF file is required by the BIT_TO_V_CMD
+add_dependencies(all_pp3_tests_bit   multiplier_8bit-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v multiplier_8bit-ql-jimbob4-pp3_bit_v) # FIXME: PCF file is required by the BIT_TO_V_CMD
 
-add_dependencies(all_ql_tests_regression multiplier_8bit-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression multiplier_8bit-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/osc_alu/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/osc_alu/CMakeLists.txt
@@ -29,11 +29,10 @@ add_openocd_output(
   PARENT osc_alu-ql-chandalar
 )
 
-add_dependencies(all_ql_tests_bit  osc_alu-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v osc_alu-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog osc_alu-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog osc_alu-ql-chandalar_openocd)
-add_dependencies(all_quick_tests osc_alu-ql-chandalar_analysis)
+add_dependencies(all_eos_s3_tests_bit  osc_alu-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v osc_alu-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog osc_alu-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog osc_alu-ql-chandalar_openocd)
 add_dependencies(osc_alu-ql-chandalar_analysis osc_alu-ql-chandalar_bit_v)
 
 
@@ -58,10 +57,7 @@ add_openocd_output(
   PARENT osc_alu-ql-pd64
 )
 
-add_dependencies(all_ql_tests_bit  osc_alu-ql-pd64_bit)
-#add_dependencies(all_ql_tests_bit_v osc_alu-ql-pd64_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
-add_dependencies(all_ql_tests_prog osc_alu-ql-pd64_jlink)
-add_dependencies(all_ql_tests_prog osc_alu-ql-pd64_openocd)
-add_dependencies(all_quick_tests osc_alu-ql-pd64_analysis)
+add_dependencies(all_pp3_tests_bit  osc_alu-ql-pd64_bit)
+#add_dependencies(all_pp3_tests_bit_v osc_alu-ql-pd64_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
 add_dependencies(osc_alu-ql-pd64_analysis osc_alu-ql-pd64_bit_v)
 

--- a/quicklogic/pp3/tests/design_flow/rgb2ycrcb/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/rgb2ycrcb/CMakeLists.txt
@@ -13,8 +13,8 @@ add_fpga_target(
   ASSERT_TIMING fmax>=10.0
 )
 
-add_dependencies(all_ql_tests_bit   rgb2ycrcb-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v rgb2ycrcb-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
+add_dependencies(all_pp3_tests_bit   rgb2ycrcb-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v rgb2ycrcb-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
 
-add_dependencies(all_ql_tests_regression rgb2ycrcb-ql-jimbob4-pp3_assert_usage)
-add_dependencies(all_ql_tests_regression rgb2ycrcb-ql-jimbob4-pp3_assert_timing)
+add_dependencies(all_pp3_tests_regression rgb2ycrcb-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression rgb2ycrcb-ql-jimbob4-pp3_assert_timing)

--- a/quicklogic/pp3/tests/design_flow/rs_decoder_1/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/rs_decoder_1/CMakeLists.txt
@@ -13,8 +13,8 @@ add_fpga_target(
   ASSERT_TIMING fmax>=25.0
 )
 
-add_dependencies(all_ql_tests_bit   rs_decoder_1-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v rs_decoder_1-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   rs_decoder_1-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v rs_decoder_1-ql-jimbob4-pp3_bit_v)
 
-add_dependencies(all_ql_tests_regression rs_decoder_1-ql-jimbob4-pp3_assert_usage)
-add_dependencies(all_ql_tests_regression rs_decoder_1-ql-jimbob4-pp3_assert_timing)
+add_dependencies(all_pp3_tests_regression rs_decoder_1-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression rs_decoder_1-ql-jimbob4-pp3_assert_timing)

--- a/quicklogic/pp3/tests/design_flow/sdio_client_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/sdio_client_top/CMakeLists.txt
@@ -29,7 +29,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=1,PB-GMUX=1,PB-LOGIC<=598
 )
 
-add_dependencies(all_ql_tests_bit   sdio_client_top-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v sdio_client_top-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
+add_dependencies(all_pp3_tests_bit   sdio_client_top-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v sdio_client_top-ql-jimbob4-pp3_bit_v)	# FIXME: List of connection types is empty (should have 1 element)
 
-add_dependencies(all_ql_tests_regression sdio_client_top-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression sdio_client_top-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/sha256/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/sha256/CMakeLists.txt
@@ -11,5 +11,5 @@ add_fpga_target(
   AUTO_ADD_FILE_TARGET
 )
 
-add_dependencies(all_ql_tests_bit   sha256-ql-pd64_bit)
-add_dependencies(all_ql_tests_bit_v sha256-ql-pd64_bit_v)
+add_dependencies(all_pp3_tests_bit   sha256-ql-pd64_bit)
+add_dependencies(all_pp3_tests_bit_v sha256-ql-pd64_bit_v)

--- a/quicklogic/pp3/tests/design_flow/sha_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/sha_top/CMakeLists.txt
@@ -11,5 +11,5 @@ add_fpga_target(
   AUTO_ADD_FILE_TARGET
 )
 
-add_dependencies(all_ql_tests_bit   sha_top-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v sha_top-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   sha_top-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v sha_top-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/design_flow/shift_reg_576/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/shift_reg_576/CMakeLists.txt
@@ -12,7 +12,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=2,PB-GMUX=2,PB-LOGIC=576
 )
 
-add_dependencies(all_ql_tests_bit   shift_reg_576-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v shift_reg_576-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   shift_reg_576-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v shift_reg_576-ql-jimbob4-pp3_bit_v)
 
-add_dependencies(all_ql_tests_regression shift_reg_576-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression shift_reg_576-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/smithwaterman/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/smithwaterman/CMakeLists.txt
@@ -10,5 +10,5 @@ add_fpga_target(
   AUTO_ADD_FILE_TARGET
 )
 
-add_dependencies(all_ql_tests_bit   smithwaterman-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v smithwaterman-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   smithwaterman-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v smithwaterman-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/design_flow/spi_master_top/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/spi_master_top/CMakeLists.txt
@@ -17,7 +17,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=2,PB-GMUX=2,PB-LOGIC<=136
 )
 
-add_dependencies(all_ql_tests_bit   spi_master_top-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v spi_master_top-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   spi_master_top-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v spi_master_top-ql-jimbob4-pp3_bit_v)
 
-add_dependencies(all_ql_tests_regression spi_master_top-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression spi_master_top-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/sudoku_check/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/sudoku_check/CMakeLists.txt
@@ -21,5 +21,5 @@ add_fpga_target(
   AUTO_ADD_FILE_TARGET
 )
 
-add_dependencies(all_ql_tests_bit   sudoku_check-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v sudoku_check-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   sudoku_check-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v sudoku_check-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/design_flow/test_logic_cell/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/test_logic_cell/CMakeLists.txt
@@ -21,10 +21,10 @@ add_openocd_output(
   PARENT test_logic_cell-ql-chandalar
 )
 
-add_dependencies(all_ql_tests_bit  test_logic_cell-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v test_logic_cell-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog test_logic_cell-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog test_logic_cell-ql-chandalar_openocd)
+add_dependencies(all_eos_s3_tests_bit  test_logic_cell-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v test_logic_cell-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog test_logic_cell-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog test_logic_cell-ql-chandalar_openocd)
 
 # FIXME: FasmInconsistentBits: enable_feature() function didn't set or clear bit for the feature: X15Y34.INTERFACE.BIDIR.INV.OSEL
 #add_fpga_target(
@@ -44,8 +44,8 @@ add_dependencies(all_ql_tests_prog test_logic_cell-ql-chandalar_openocd)
   #PARENT test_logic_cell-ql-jimbob4
 #)
 
-#add_dependencies(all_ql_tests_bit  test_logic_cell-ql-jimbob4_bit)
-#add_dependencies(all_ql_tests_bit_v test_logic_cell-ql-jimbob4_bit_v)
+#add_dependencies(all_pp3e_tests_bit  test_logic_cell-ql-jimbob4_bit)
+#add_dependencies(all_pp3e_tests_bit_v test_logic_cell-ql-jimbob4_bit_v)
 
 add_fpga_target(
   NAME test_logic_cell-ql-jimbob4-pp3
@@ -64,5 +64,5 @@ add_openocd_output(
   PARENT test_logic_cell-ql-jimbob4-pp3
 )
 
-add_dependencies(all_ql_tests_bit  test_logic_cell-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v test_logic_cell-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit  test_logic_cell-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v test_logic_cell-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/design_flow/top_120_13/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/top_120_13/CMakeLists.txt
@@ -12,7 +12,7 @@ add_fpga_target(
   ASSERT_USAGE PB-CLOCK=3,PB-GMUX=3,PB-LOGIC<=380
 )
 
-add_dependencies(all_ql_tests_bit   top_120_13-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v top_120_13-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   top_120_13-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v top_120_13-ql-jimbob4-pp3_bit_v)
 
-add_dependencies(all_ql_tests_regression top_120_13-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression top_120_13-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/unsigned_mult_50/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/unsigned_mult_50/CMakeLists.txt
@@ -11,7 +11,7 @@ add_fpga_target(
   ASSERT_USAGE PB-LOGIC<=908
 )
 
-add_dependencies(all_ql_tests_bit   unsigned_mult_50-ql-jimbob4-pp3_bit)
-#add_dependencies(all_ql_tests_bit_v unsigned_mult_50-ql-jimbob4-pp3_bit_v)	# FIXME: PCF file is required by the BIT_TO_V_CMD
+add_dependencies(all_pp3_tests_bit   unsigned_mult_50-ql-jimbob4-pp3_bit)
+#add_dependencies(all_pp3_tests_bit_v unsigned_mult_50-ql-jimbob4-pp3_bit_v)	# FIXME: PCF file is required by the BIT_TO_V_CMD
 
-add_dependencies(all_ql_tests_regression unsigned_mult_50-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression unsigned_mult_50-ql-jimbob4-pp3_assert_usage)

--- a/quicklogic/pp3/tests/design_flow/unsigned_mult_80/CMakeLists.txt
+++ b/quicklogic/pp3/tests/design_flow/unsigned_mult_80/CMakeLists.txt
@@ -9,5 +9,5 @@ add_fpga_target(
   AUTO_ADD_FILE_TARGET
 )
 
-add_dependencies(all_ql_tests_bit   unsigned_mult_80-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v unsigned_mult_80-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit   unsigned_mult_80-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v unsigned_mult_80-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/ext_counter/CMakeLists.txt
@@ -18,19 +18,10 @@ add_openocd_output(
   PARENT ext_counter-ql-chandalar
 )
 
-add_dependencies(all_quick_tests ext_counter-ql-chandalar_bit)
-add_dependencies(all_quick_tests ext_counter-ql-chandalar_jlink)
-add_dependencies(all_quick_tests ext_counter-ql-chandalar_openocd)
-add_dependencies(all_quick_tests ext_counter-ql-chandalar_jlink_test)
-add_dependencies(all_quick_tests ext_counter-ql-chandalar_openocd_test)
-
-add_dependencies(all_ql_tests_bit ext_counter-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v ext_counter-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_openocd)
-add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_jlink_test)
-add_dependencies(all_ql_tests_prog ext_counter-ql-chandalar_openocd_test)
-
+add_dependencies(all_eos_s3_tests_bit ext_counter-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v ext_counter-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog ext_counter-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog ext_counter-ql-chandalar_openocd)
 
 add_file_target(FILE quickfeather.pcf)
 
@@ -50,13 +41,10 @@ add_openocd_output(
   PARENT ext_counter-ql-quickfeather
 )
 
-add_dependencies(all_ql_tests_bit ext_counter-ql-quickfeather_bit)
-add_dependencies(all_ql_tests_bit_v ext_counter-ql-quickfeather_bit_v)
-add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_jlink)
-add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_openocd)
-add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_jlink_test)
-add_dependencies(all_ql_tests_prog ext_counter-ql-quickfeather_openocd_test)
-
+add_dependencies(all_eos_s3_tests_bit ext_counter-ql-quickfeather_bit)
+add_dependencies(all_eos_s3_tests_bit_v ext_counter-ql-quickfeather_bit_v)
+add_dependencies(all_eos_s3_tests_prog ext_counter-ql-quickfeather_jlink)
+add_dependencies(all_eos_s3_tests_prog ext_counter-ql-quickfeather_openocd)
 
 add_fpga_target(
   NAME ext_counter-ql-jimbob4
@@ -74,11 +62,8 @@ add_openocd_output(
   PARENT ext_counter-ql-jimbob4
 )
 
-add_dependencies(all_quick_tests ext_counter-ql-jimbob4_bit)
-
-add_dependencies(all_ql_tests_bit ext_counter-ql-jimbob4_bit)
-#add_dependencies(all_ql_tests_bit_v ext_counter-ql-jimbob4_bit_v)	# Failure in mux expanding
-
+add_dependencies(all_pp3e_tests_bit ext_counter-ql-jimbob4_bit)
+#add_dependencies(all_pp3e_tests_bit_v ext_counter-ql-jimbob4_bit_v)	# Failure in mux expanding
 
 add_fpga_target(
   NAME ext_counter-ql-jimbob4-pp3
@@ -96,7 +81,5 @@ add_openocd_output(
   PARENT ext_counter-ql-jimbob4-pp3
 )
 
-add_dependencies(all_quick_tests ext_counter-ql-jimbob4-pp3_bit)
-
-add_dependencies(all_ql_tests_bit ext_counter-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v ext_counter-ql-jimbob4-pp3_bit_v)
+add_dependencies(all_pp3_tests_bit ext_counter-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v ext_counter-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/ext_mult/CMakeLists.txt
+++ b/quicklogic/pp3/tests/ext_mult/CMakeLists.txt
@@ -10,8 +10,7 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_ql_tests ext_mult-ql-chandalar_route)
-add_dependencies(all_quick_tests ext_mult-ql-chandalar_analysis)
+add_dependencies(all_eos_s3_tests ext_mult-ql-chandalar_route)
 add_dependencies(ext_mult-ql-chandalar_analysis ext_mult-ql-chandalar_bit_v)
 
 
@@ -23,7 +22,6 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_ql_tests ext_mult-ql-pd64_route)
-add_dependencies(all_quick_tests ext_mult-ql-pd64_analysis)
+add_dependencies(all_pp3_tests ext_mult-ql-pd64_route)
 add_dependencies(ext_mult-ql-pd64_analysis ext_mult-ql-pd64_bit_v)
 

--- a/quicklogic/pp3/tests/features/counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/counter/CMakeLists.txt
@@ -12,7 +12,7 @@ add_fpga_target(
   ASSERT_TIMING fmax>40.0
 )
 
-add_dependencies(all_ql_tests_regression regression-counter-ql-quickfeather_assert_usage)
+add_dependencies(all_eos_s3_tests_regression regression-counter-ql-quickfeather_assert_usage)
 
 add_fpga_target(
   NAME regression-counter-ql-jimbob4-pp3
@@ -24,5 +24,5 @@ add_fpga_target(
   ASSERT_TIMING fmax>40.0
 )
 
-add_dependencies(all_ql_tests_regression regression-counter-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression regression-counter-ql-jimbob4-pp3_assert_usage)
 

--- a/quicklogic/pp3/tests/features/counter_gclk/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/counter_gclk/CMakeLists.txt
@@ -12,7 +12,7 @@ add_fpga_target(
   ASSERT_TIMING fmax>55.0
 )
 
-add_dependencies(all_ql_tests_regression regression-counter_gclk-ql-quickfeather_assert_usage)
+add_dependencies(all_eos_s3_tests_regression regression-counter_gclk-ql-quickfeather_assert_usage)
 
 add_fpga_target(
   NAME regression-counter_gclk-ql-jimbob4-pp3
@@ -24,5 +24,5 @@ add_fpga_target(
   ASSERT_TIMING fmax>55.0
 )
 
-add_dependencies(all_ql_tests_regression regression-counter_gclk-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression regression-counter_gclk-ql-jimbob4-pp3_assert_usage)
 

--- a/quicklogic/pp3/tests/features/fifo/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/fifo/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach(FIELDS ${CONFIGURATIONS})
       ASSERT_USAGE PB-CLOCK=${NUM_CLK},PB-GMUX=${NUM_CLK},PB-RAM=${RAM_COUNT}
     )
 
-    add_dependencies(all_ql_tests_regression regression-fifo_${TYPE}${NAME}-ql-chandalar_assert_usage)
+    add_dependencies(all_eos_s3_tests_regression regression-fifo_${TYPE}${NAME}-ql-chandalar_assert_usage)
 
     add_fpga_target(
       NAME regression-fifo_${TYPE}${NAME}-ql-pd64
@@ -48,6 +48,6 @@ foreach(FIELDS ${CONFIGURATIONS})
       ASSERT_USAGE PB-CLOCK=${NUM_CLK},PB-GMUX=${NUM_CLK},PB-RAM=${RAM_COUNT}
     )
 
-    add_dependencies(all_ql_tests_regression regression-fifo_${TYPE}${NAME}-ql-pd64_assert_usage)
+    add_dependencies(all_pp3_tests_regression regression-fifo_${TYPE}${NAME}-ql-pd64_assert_usage)
 
 endforeach()

--- a/quicklogic/pp3/tests/features/ram/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/ram/CMakeLists.txt
@@ -28,7 +28,7 @@ foreach(FIELDS ${CONFIGURATIONS})
       ASSERT_USAGE PB-CLOCK=2,PB-GMUX=2,PB-RAM=${RAM_COUNT}
     )
 
-    add_dependencies(all_ql_tests_regression regression-ram_${NAME}-ql-chandalar_assert_usage)
+    add_dependencies(all_eos_s3_tests_regression regression-ram_${NAME}-ql-chandalar_assert_usage)
 
     add_fpga_target(
       NAME regression-ram_${NAME}-ql-pd64
@@ -39,6 +39,6 @@ foreach(FIELDS ${CONFIGURATIONS})
       ASSERT_USAGE PB-CLOCK=2,PB-GMUX=2,PB-RAM=${RAM_COUNT}
     )
 
-    add_dependencies(all_ql_tests_regression regression-ram_${NAME}-ql-pd64_assert_usage)
+    add_dependencies(all_pp3_tests_regression regression-ram_${NAME}-ql-pd64_assert_usage)
 
 endforeach()

--- a/quicklogic/pp3/tests/features/ram_inference/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/ram_inference/CMakeLists.txt
@@ -12,7 +12,7 @@ add_fpga_target(
   ASSERT_TIMING fmax>30.0
 )
 
-add_dependencies(all_ql_tests_regression regression-ram_inference-ql-chandalar_assert_usage)
+add_dependencies(all_eos_s3_tests_regression regression-ram_inference-ql-chandalar_assert_usage)
 
 add_fpga_target(
   NAME regression-ram_inference-ql-jimbob4-pp3
@@ -24,5 +24,5 @@ add_fpga_target(
   ASSERT_TIMING fmax>30.0
 )
 
-add_dependencies(all_ql_tests_regression regression-ram_inference-ql-jimbob4-pp3_assert_usage)
+add_dependencies(all_pp3_tests_regression regression-ram_inference-ql-jimbob4-pp3_assert_usage)
 

--- a/quicklogic/pp3/tests/lut/CMakeLists.txt
+++ b/quicklogic/pp3/tests/lut/CMakeLists.txt
@@ -37,16 +37,12 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_ql_tests lut1-ql-chandalar_route)
-add_dependencies(all_ql_tests lut2-ql-chandalar_route)
-add_dependencies(all_ql_tests lut3-ql-chandalar_route)
-add_dependencies(all_ql_tests lut4-ql-chandalar_route)
+add_dependencies(all_eos_s3_tests lut1-ql-chandalar_route)
+add_dependencies(all_eos_s3_tests lut2-ql-chandalar_route)
+add_dependencies(all_eos_s3_tests lut3-ql-chandalar_route)
+add_dependencies(all_eos_s3_tests lut4-ql-chandalar_route)
 
 
-add_dependencies(all_quick_tests lut1-ql-chandalar_bit)
-add_dependencies(all_quick_tests lut2-ql-chandalar_bit)
-add_dependencies(all_quick_tests lut3-ql-chandalar_bit)
-add_dependencies(all_quick_tests lut4-ql-chandalar_bit)
 
 add_fpga_target(
   NAME lut1-ql-jimbob4
@@ -80,10 +76,10 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_ql_tests lut1-ql-jimbob4_route)
-add_dependencies(all_ql_tests lut2-ql-jimbob4_route)
-add_dependencies(all_ql_tests lut3-ql-jimbob4_route)
-add_dependencies(all_ql_tests lut4-ql-jimbob4_route)
+add_dependencies(all_pp3e_tests lut1-ql-jimbob4_route)
+add_dependencies(all_pp3e_tests lut2-ql-jimbob4_route)
+add_dependencies(all_pp3e_tests lut3-ql-jimbob4_route)
+add_dependencies(all_pp3e_tests lut4-ql-jimbob4_route)
 
 add_fpga_target(
   NAME lut1-ql-jimbob4-pp3
@@ -117,7 +113,7 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_ql_tests lut1-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests lut2-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests lut3-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests lut4-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests lut1-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests lut2-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests lut3-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests lut4-ql-jimbob4-pp3_bit)

--- a/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
+++ b/quicklogic/pp3/tests/sdiomux_xor/CMakeLists.txt
@@ -18,18 +18,10 @@ add_openocd_output(
   PARENT sdiomux_xor-ql-chandalar
 )
 
-add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_bit)
-add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_jlink)
-add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_openocd)
-add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_jlink_test)
-add_dependencies(all_quick_tests sdiomux_xor-ql-chandalar_openocd_test)
-
-add_dependencies(all_ql_tests_bit sdiomux_xor-ql-chandalar_bit)
-add_dependencies(all_ql_tests_bit_v sdiomux_xor-ql-chandalar_bit_v)
-add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_jlink)
-add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_openocd)
-add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_jlink_test)
-add_dependencies(all_ql_tests_prog sdiomux_xor-ql-chandalar_openocd_test)
+add_dependencies(all_eos_s3_tests_bit sdiomux_xor-ql-chandalar_bit)
+add_dependencies(all_eos_s3_tests_bit_v sdiomux_xor-ql-chandalar_bit_v)
+add_dependencies(all_eos_s3_tests_prog sdiomux_xor-ql-chandalar_jlink)
+add_dependencies(all_eos_s3_tests_prog sdiomux_xor-ql-chandalar_openocd)
 
 add_fpga_target(
   NAME sdiomux_xor-ql-jimbob4
@@ -47,10 +39,8 @@ add_openocd_output(
   PARENT sdiomux_xor-ql-jimbob4
 )
 
-add_dependencies(all_quick_tests sdiomux_xor-ql-jimbob4_bit)
-
-add_dependencies(all_ql_tests_bit sdiomux_xor-ql-jimbob4_bit)
-#add_dependencies(all_ql_tests_bit_v sdiomux_xor-ql-jimbob4_bit_v)	# Failure in mux expanding
+add_dependencies(all_pp3e_tests_bit sdiomux_xor-ql-jimbob4_bit)
+#add_dependencies(all_pp3e_tests_bit_v sdiomux_xor-ql-jimbob4_bit_v)	# Failure in mux expanding
 
 add_fpga_target(
   NAME sdiomux_xor-ql-jimbob4-pp3
@@ -68,8 +58,5 @@ add_openocd_output(
   PARENT sdiomux_xor-ql-jimbob4-pp3
 )
 
-add_dependencies(all_quick_tests sdiomux_xor-ql-jimbob4-pp3_bit)
-
-add_dependencies(all_ql_tests_bit sdiomux_xor-ql-jimbob4-pp3_bit)
-add_dependencies(all_ql_tests_bit_v sdiomux_xor-ql-jimbob4-pp3_bit_v)
-
+add_dependencies(all_pp3_tests_bit sdiomux_xor-ql-jimbob4-pp3_bit)
+add_dependencies(all_pp3_tests_bit_v sdiomux_xor-ql-jimbob4-pp3_bit_v)

--- a/quicklogic/pp3/tests/wire/CMakeLists.txt
+++ b/quicklogic/pp3/tests/wire/CMakeLists.txt
@@ -18,10 +18,9 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_quick_tests wire-ql-chandalar_route)
 
-add_dependencies(all_ql_tests wire-ql-chandalar_route)
-add_dependencies(all_ql_tests wire-ql-jimbob4_route)
+add_dependencies(all_eos_s3_tests wire-ql-chandalar_route)
+add_dependencies(all_pp3e_tests wire-ql-jimbob4_route)
 
 add_fpga_target(
   NAME wire-ql-jimbob4-pp3
@@ -31,4 +30,4 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
-add_dependencies(all_ql_tests wire-ql-jimbob4-pp3_route)
+add_dependencies(all_pp3_tests wire-ql-jimbob4-pp3_route)

--- a/quicklogic/pp3/utils/CMakeLists.txt
+++ b/quicklogic/pp3/utils/CMakeLists.txt
@@ -1,7 +1,7 @@
 get_target_property_required(PYTHON3 env PYTHON3)
 
 # Add a target that runs tests for Python utils
-add_custom_target(pp3_python_tests
+add_custom_target(all_pp3_python_tests
     COMMAND
         ${CMAKE_COMMAND} -E env
         PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils:${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/common/utils:$PYTHONPATH
@@ -9,4 +9,4 @@ add_custom_target(pp3_python_tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_dependencies(all_quicklogic_tests all_python_tests pp3_python_tests)
+add_dependencies(all_quicklogic_python_tests all_pp3_python_tests)

--- a/quicklogic/qlf_k4n8/tests/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/CMakeLists.txt
@@ -1,10 +1,13 @@
 set(QL_DESIGNS_DIR ../../../../../quicklogic/designs)
 
+add_custom_target(all_qlf_k4n8_tests)
 add_custom_target(all_qlf_k4n8_tests_no_adder)
 add_custom_target(all_qlf_k4n8_tests_adder)
 
 add_subdirectory(design_flow)
 add_subdirectory(features)
 add_subdirectory(synth_flow)
-add_dependencies(all_quicklogic_tests all_qlf_k4n8_tests_no_adder)
-add_dependencies(all_quicklogic_tests all_qlf_k4n8_tests_adder)
+
+add_dependencies(all_qlf_k4n8_tests all_qlf_k4n8_tests_no_adder)
+add_dependencies(all_qlf_k4n8_tests all_qlf_k4n8_tests_adder)
+add_dependencies(all_quicklogic_tests all_qlf_k4n8_tests)

--- a/quicklogic/qlf_k6n10/tests/CMakeLists.txt
+++ b/quicklogic/qlf_k6n10/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(QL_DESIGNS_DIR ../../../../../quicklogic/designs)
 
+add_custom_target(all_qlf_k6n10_tests)
 add_custom_target(all_qlf_k6n10_tests_no_adder)
 add_custom_target(all_qlf_k6n10_tests_adder)
 
@@ -7,5 +8,6 @@ add_subdirectory(design_flow)
 add_subdirectory(synth_flow)
 add_subdirectory(features)
 
-add_dependencies(all_quicklogic_tests all_qlf_k6n10_tests_no_adder)
-add_dependencies(all_quicklogic_tests all_qlf_k6n10_tests_adder)
+add_dependencies(all_qlf_k6n10_tests all_qlf_k6n10_tests_no_adder)
+add_dependencies(all_qlf_k6n10_tests all_qlf_k6n10_tests_adder)
+add_dependencies(all_quicklogic_tests all_qlf_k6n10_tests)


### PR DESCRIPTION
This PR splits the GH actions CI into multiple parallel jobs - one for each supported device. It also reorganizes CMake targets for tests so that they are defined per-device as well. This should prevent the CI from timing out and failing.