### PR TITLE
PP3: fix bitstream generation

### DIFF
--- a/quicklogic/common/toolchain_wrappers/symbiflow_generate_bitstream
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_generate_bitstream
@@ -65,8 +65,11 @@ if [[ "$DEVICE" =~ ^(qlf_k4n8.*)$ ]]; then
     DB_ROOT=`realpath ${MYPATH}/../share/symbiflow/fasm_database/${DEVICE}`
     ${QLF_FASM} --db-root ${DB_ROOT} --format ${BIT_FORMAT} --assemble $FASM $BIT
 
-elif [[ "$DEVICE" =~ ^(ql-eos-s3|ql-pp3|ql-pp3e)$ ]]; then
+elif [[ "$DEVICE" =~ ^(ql-eos-s3|ql-pp3e)$ ]]; then
     qlfasm --dev-type ${DEVICE} ${FASM} ${BIT}
+
+elif [[ "$DEVICE" =~ ^(ql-pp3)$ ]]; then
+    qlfasm --no-default-bitstream --dev-type ${DEVICE} ${FASM} ${BIT}
 
 else
 

--- a/quicklogic/pp3/CMakeLists.txt
+++ b/quicklogic/pp3/CMakeLists.txt
@@ -85,7 +85,7 @@ define_arch(
     ${QLFASM}
   FASM_TO_BIT_CMD "\${PYTHON3} \
     \${QLFASM} \
-    --dev-type \${DEVICE}
+    --no-default-bitstream --dev-type \${DEVICE}
         \${OUT_FASM}
         \${OUT_BITSTREAM}
         \${FASM_TO_BIT_EXTRA_ARGS}"

--- a/quicklogic/pp3/utils/fasm2bels.py
+++ b/quicklogic/pp3/utils/fasm2bels.py
@@ -1118,8 +1118,8 @@ if __name__ == '__main__':
             assembler = QL725AAssembler(
                 qlfasmdb,
                 spi_master=True,
-                osc_freq=True,
-                cfg_write_chcksum_post=True,
+                osc_freq=False,
+                cfg_write_chcksum_post=False,
                 cfg_read_chcksum_post=False,
                 cfg_done_out_mask=False,
                 add_header=True,


### PR DESCRIPTION
This PR together with https://github.com/QuickLogic-Corp/quicklogic-fasm/pull/24 sets default PP3 assembler settings to match the configuration required for testing on HW. (https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/659)
It changes the default oscillator frequency to 5MHz and the moment when the checksum is being verified during programming of the device.
It also disables the concatenation of default bitstream with design configuration to fix issue described in https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/640#issuecomment-969838757
