### PR TITLE
2 post layout verilogs

### DIFF
--- a/quicklogic/common/cmake/run_toolchain_test.cmake
+++ b/quicklogic/common/cmake/run_toolchain_test.cmake
@@ -66,3 +66,21 @@ set(OUT_PCF  ${BUILD_DIR}/top.bit.v.pcf)
 if (NOT "${REF_PCF}" STREQUAL "")
     run("PYTHONPATH=${PYTHONPATH} python3 ${PCF_UTIL} ${REF_PCF} ${OUT_PCF}")
 endif()
+
+# Check if post synthesis verilog has correct format
+# We look for verilog escaped identifiers ending with array indexing, e.g. [0]
+# POST_SYNTH_NO_SPLIT shouldn't contain such identifiers
+set(POST_SYNTH_NO_SPLIT	${BUILD_DIR}/top_post_synthesis.no_split.v)
+
+if (EXISTS "${POST_SYNTH_NO_SPLIT}")
+    SET(GREP_ARGS \\\S*\[[0-9]*\]\s ${POST_SYNTH_NO_SPLIT})
+    EXECUTE_PROCESS(
+        COMMAND
+        grep ${GREP_ARGS}
+        OUTPUT_VARIABLE NO_SPLIT_VAL_OUT
+        RESULT_VARIABLE NO_SPLIT_VAL_RES)
+
+    if (${NO_SPLIT_VAL_RES} EQUAL 0 AND NOT "${NO_SPLIT_VAL_OUT}" STREQUAL "")
+        MESSAGE(FATAL_ERROR "Found illegal escaped identifiers in ${POST_SYNTH_NO_SPLIT}: ${NO_SPLIT_VAL_OUT}")
+    endif()
+endif()

--- a/quicklogic/pp3/CMakeLists.txt
+++ b/quicklogic/pp3/CMakeLists.txt
@@ -113,6 +113,9 @@ define_arch(
 
   ROUTE_CHAN_WIDTH 100
   USE_FASM
+
+  FIXUP_POST_SYNTHESIS_EXTRA_ARGS
+    --split-ports
 )
 
 add_subdirectory(devices)

--- a/quicklogic/pp3/tests/features/install_test/counter/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/install_test/counter/CMakeLists.txt
@@ -11,6 +11,7 @@ add_binary_toolchain_test(
 
     ASSERT_EXISTS
         "top_post_synthesis.v"
+        "top_post_synthesis.no_split.v"
         "top_post_synthesis.sdf"
         "top.bit.v"
         "top.bit.v.pcf"
@@ -30,6 +31,7 @@ add_binary_toolchain_test(
 
     ASSERT_EXISTS
         "top_post_synthesis.v"
+        "top_post_synthesis.no_split.v"
         "top_post_synthesis.sdf"
         "top.bit.v"
         "top.bit.v.pcf"
@@ -49,6 +51,7 @@ add_binary_toolchain_test(
 
     ASSERT_EXISTS
         "top_post_synthesis.v"
+        "top_post_synthesis.no_split.v"
         "top_post_synthesis.sdf"
         "top.bit.v"
         "top.bit.v.pcf"

--- a/quicklogic/pp3/tests/features/install_test/counter_assp/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/install_test/counter_assp/CMakeLists.txt
@@ -10,6 +10,7 @@ add_binary_toolchain_test(
 
     ASSERT_EXISTS
         "top_post_synthesis.v"
+        "top_post_synthesis.no_split.v"
         "top_post_synthesis.sdf"
         "top.bit.v"
         "top.bit.v.pcf"

--- a/quicklogic/pp3/tests/features/install_test/counter_gclk/CMakeLists.txt
+++ b/quicklogic/pp3/tests/features/install_test/counter_gclk/CMakeLists.txt
@@ -11,6 +11,7 @@ add_binary_toolchain_test(
 
     ASSERT_EXISTS
         "top_post_synthesis.v"
+        "top_post_synthesis.no_split.v"
         "top_post_synthesis.sdf"
         "top.bit.v"
         "top.bit.v.pcf"
@@ -30,6 +31,7 @@ add_binary_toolchain_test(
 
     ASSERT_EXISTS
         "top_post_synthesis.v"
+        "top_post_synthesis.no_split.v"
         "top_post_synthesis.sdf"
         "top.bit.v"
         "top.bit.v.pcf"
@@ -49,6 +51,7 @@ add_binary_toolchain_test(
 
     ASSERT_EXISTS
         "top_post_synthesis.v"
+        "top_post_synthesis.no_split.v"
         "top_post_synthesis.sdf"
         "top.bit.v"
         "top.bit.v.pcf"


### PR DESCRIPTION
This PR modifies `vpr_fixup_post_synth` script in order to enable writing 2 versions of post-layout verilog with use of `--split-ports` flag: 
* one with its top module ports split (filename.v)
* second with regular IO (filename.no_split.v)
This actually required separate function for merging the ports because the split partially takes place in the VPR flow and not in `vpr_fixup_post_synth` script.

As for the SDF, it is unnecessary to write two versions of them because SDF refers only to the internal ports of the specific cells and not to the top IO. Those internal ports remain unchanged in verilog so there is no need to change them in SDF