### PR TITLE
Fix issues in this repo for k4n8 and k6n10

### DIFF
--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -227,7 +227,7 @@ else
 if [ -f $SOURCE/v_list_tmp ];then
 rm -f $SOURCE/v_list_tmp
 fi
-if [ $VERILOG_FILES == "*.v" ];then
+if [ "$VERILOG_FILES" == "*.v" ];then
         VERILOG_FILES=`cd ${SOURCE};ls *.v`
 fi
 echo "$VERILOG_FILES" >${SOURCE}/v_list

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -263,7 +263,7 @@ if [[ $1 == "-compile" || $1 == "-post_verilog" ]]; then
   fi
   if [[  "$DEVICE_CHECK" =~ ^(VALID)$ ]]; then
     if [ -z "$PART" ]; then
-	   if [ -n "$PCF" && $USE_PINMAP -ne 0 ]; then
+	   if [[ -n "$PCF" && $USE_PINMAP -ne 0 ]]; then
 	     echo "Error: pcf file cannot be used without declaring PINMAP CSV file"
          exit 1
        fi
@@ -440,6 +440,7 @@ all: \${BUILDDIR}/\${TOP}.${RUN_TILL}\n\
 \n\
 \${BUILDDIR}/\${TOP}.sdc: \${BUILDDIR}/\${TOP}.eblif\n\
 	python3 ${PROCESS_SDC} --sdc-in \${SDC_IN} --sdc-out \$@ --pcf \${PCF} --eblif \${BUILDDIR}/\${TOP}.eblif --pin-map \${PINMAP_CSV}\n\
+\n\
 \${BUILDDIR}/\${TOP}.net: \${BUILDDIR}/\${TOP}.eblif \${BUILDDIR}/\${TOP}.sdc\n\
 	cd \${BUILDDIR} && symbiflow_pack -e \${TOP}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} -c \${PNR_CORNER} >> $LOG_FILE 2>&1\n\
 \n\
@@ -493,20 +494,18 @@ fi
 # EOS-S3 specific targets
 if [ "$DEVICE" == "ql-eos-s3" ]; then
     echo -e "\
-\${TOP}_bit.h: \${BUILDDIR}/\${TOP}.bit\n\
+\${BUILDDIR}/\${TOP}_bit.h: \${BUILDDIR}/\${TOP}.bit\n\
 	symbiflow_write_bitheader \$^ \$@ >> $LOG_FILE 2>&1\n\
 \n\
 \${BUILDDIR}/\${TOP}.bin: \${BUILDDIR}/\${TOP}.bit\n\
-	cd \${BUILDDIR} && symbiflow_write_binary -b \${TOP}.bit >> $LOG_FILE 2>&1\n\
+	symbiflow_write_binary \$^ \$@ >> $LOG_FILE 2>&1\n\
 \n\
-\${TOP}.jlink: \${BUILDDIR}/\${TOP}.bit\n\
+\${BUILDDIR}/\${TOP}.jlink: \${BUILDDIR}/\${TOP}.bit\n\
 	symbiflow_write_jlink \$^ \$@ >> $LOG_FILE 2>&1\n\
 \n\
-\${TOP}.openocd: \${BUILDDIR}/\${TOP}.bit\n\
+\${BUILDDIR}/\${TOP}.openocd: \${BUILDDIR}/\${TOP}.bit\n\
 	symbiflow_write_openocd \$^ \$@ >> $LOG_FILE 2>&1\n\
 \n\
-\${BUILDDIR}/\${TOP}_jlink.h: \${BUILDDIR}/\${TOP}.jlink >> $LOG_FILE 2>&1\n\
-	cd \${BUILDDIR} && symbiflow_write_jlinkheader\n\
     " >>$MAKE_FILE
 fi
 
@@ -529,43 +528,43 @@ rm -f $SOURCE/f_list_temp $SOURCE/v_list_tmp $SOURCE/v_list
 ##### Make file Targets #####
 if [ $1 == "-synth" ]; then
   echo -e "Performing Synthesis "
-  cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.eblif || (cat $LOG_FILE && exit)
+  cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.eblif || (cat $LOG_FILE && exit 1)
 elif [[ ! -z "$OUT" && $1 == "-compile" ]];then
 	if [[ " ${OUT_ARR[@]} " =~ " post_verilog " ]];then
-		cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.post_v || (cat $LOG_FILE && exit)
+		cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.post_v || (cat $LOG_FILE && exit 1)
 	fi
 
     if [ "$DEVICE" == "ql-eos-s3" ]; then
       if [[ " ${OUT_ARR[@]} " =~ " jlink " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.jlink || (cat $LOG_FILE && exit)
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.jlink || (cat $LOG_FILE && exit 1)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " openocd " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.openocd || (cat $LOG_FILE && exit)
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.openocd || (cat $LOG_FILE && exit 1)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " post_verilog " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow  ${BUILDDIR}/${TOP}.bit.v || (cat $LOG_FILE && exit)
+       cd $SOURCE;make -f Makefile.symbiflow  ${BUILDDIR}/${TOP}.bit.v || (cat $LOG_FILE && exit 1)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " header " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}_bit.h || (cat $LOG_FILE && exit)
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}_bit.h || (cat $LOG_FILE && exit 1)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " binary " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bit || (cat $LOG_FILE && exit)
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bin || (cat $LOG_FILE && exit 1)
       fi
     fi
 
     if [ "$DEVICE" == "ql-pp3" ]; then
       if [[ " ${OUT_ARR[@]} " =~ " post_verilog " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow  ${BUILDDIR}/${TOP}.bit.v || (cat $LOG_FILE && exit)
+       cd $SOURCE;make -f Makefile.symbiflow  ${BUILDDIR}/${TOP}.bit.v || (cat $LOG_FILE && exit 1)
       fi
       if [[ " ${OUT_ARR[@]} " =~ " binary " ]]; then
-       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bit || (cat $LOG_FILE && exit)
+       cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bit || (cat $LOG_FILE && exit 1)
       fi
     fi
 
 else
   if [ $1 == "-compile" ]; then
   echo -e "Running Synth->Pack->Place->Route->FASM->bitstream"
-    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.${RUN_TILL} || (cat $LOG_FILE && exit)
+    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.${RUN_TILL} || (cat $LOG_FILE && exit 1)
   fi
 fi
 

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -11,7 +11,7 @@ VERSION="v2.0.1"
 
 if [ ! -n $1 ]; then
 echo "Please enter a valid command: Refer help ql_symbiflow --help"
-exit 0
+exit 1
 elif [[ $1 == "-synth" || $1 == "-compile" ]]; then
 echo -e "----------------- \n"
 elif [[ $1 == "-h"  ||  $1 == "--help" ]];then
@@ -25,10 +25,10 @@ Support temporarily disabled for: qlf_k6n10" || exit
 
 elif [[ $1 == "-v" || $1 == "--version" ]];then
         echo "Symbiflow Tool Version : ${VERSION}"
-        exit
+        exit 0
 else
 echo -e "Please provide a valid command : Refer -h/--help\n"
-exit
+exit 1
 fi
 
 


### PR DESCRIPTION
- correct exit codes to be non-zero when make steps fail in ql_symbiflow wrapper, like at: https://github.com/QuickLogic-Corp/symbiflow-arch-defs/blob/54803801d8f94a79f7b5c7b9ffa284a83182f5a2/quicklogic/common/toolchain_wrappers/ql_symbiflow#L568

- correct error in usage of `[` in bash if we use `&&` in https://github.com/QuickLogic-Corp/symbiflow-arch-defs/blob/54803801d8f94a79f7b5c7b9ffa284a83182f5a2/quicklogic/common/toolchain_wrappers/ql_symbiflow#L266

- minor aesthetic change in generated Makefile.symbiflow

This is a WIP, and more changes might be needed after testing.