### PR TITLE
add symbiflow_write_binary wrapper to installation cmake

### DIFF
--- a/quicklogic/common/cmake/quicklogic_install.cmake
+++ b/quicklogic/common/cmake/quicklogic_install.cmake
@@ -36,6 +36,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
         symbiflow_route
         symbiflow_synth
         symbiflow_write_fasm
+        symbiflow_write_binary
         symbiflow_write_bitheader
         symbiflow_write_jlink
         symbiflow_write_openocd


### PR DESCRIPTION
`symbiflow_write_binary` wrapper is missing from the arch-defs tarball used in the toolchain installation because this was not added in the installation cmake list.

missed from previous PR: #708 

This PR adds the `symbiflow_write_binary` wrapper into the installation, along with the other wrappers.