### PR TITLE
Rework BIDIR cell model in PP3 arch

### DIFF
--- a/quicklogic/passthrough.eblif
+++ b/quicklogic/passthrough.eblif
@@ -1,8 +1,8 @@
 .model top
 .inputs I
 .outputs O
-.subckt BIDIR_CELL I_DAT=x I_PAD_$inp=I
+.subckt BIDIR_CELL IZ=x PAD_$inp=I
 .cname ibuf
-.subckt BIDIR_CELL O_DAT=x O_PAD_$out=O
+.subckt BIDIR_CELL OQI=x PAD_$out=O
 .cname obuf
 .end

--- a/quicklogic/pp3/primitives/bidir/bidir.pb_type.xml
+++ b/quicklogic/pp3/primitives/bidir/bidir.pb_type.xml
@@ -40,27 +40,51 @@ INV.DS=DS</meta>
       </pb_type>
       <interconnect>
         <direct>
-          <port name="INEN" type="input"/>
-          <port name="I_EN" type="output" from="bidir"/>
-        </direct>
-        <direct>
           <port name="inpad" type="input" from="inpad"/>
-          <port name="I_PAD_$inp" type="output" from="bidir"/>
+          <port name="PAD_$inp" type="output" from="bidir"/>
           <pack_pattern name="IPAD_TO_BIDIR" type="pack">
             <port name="inpad" type="input" from="inpad"/>
-            <port name="I_PAD_$inp" type="output" from="bidir"/>
+            <port name="PAD_$inp" type="output" from="bidir"/>
           </pack_pattern>
         </direct>
         <direct>
-          <port name="OQI" type="input"/>
-          <port name="O_DAT" type="output" from="bidir"/>
+          <port name="IQC" type="input"/>
+          <port name="IQC" type="output" from="bidir"/>
         </direct>
         <direct>
           <port name="IE" type="input"/>
-          <port name="O_EN" type="output" from="bidir"/>
+          <port name="IE" type="output" from="bidir"/>
         </direct>
         <direct>
-          <port name="I_DAT" type="input" from="bidir"/>
+          <port name="INEN" type="input"/>
+          <port name="INEN" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQE" type="input"/>
+          <port name="IQE" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQIN" type="input"/>
+          <port name="IQIN" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQR" type="input"/>
+          <port name="IQR" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="OQE" type="input"/>
+          <port name="OQE" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="OQI" type="input"/>
+          <port name="OQI" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQZ" type="input" from="bidir"/>
+          <port name="IQZ" type="output"/>
+        </direct>
+        <direct>
+          <port name="IZ" type="input" from="bidir"/>
           <port name="IZ" type="output"/>
         </direct>
       </interconnect>
@@ -138,28 +162,52 @@ INV.DS=DS</meta>
       </pb_type>
       <interconnect>
         <direct>
-          <port name="INEN" type="input"/>
-          <port name="I_EN" type="output" from="bidir"/>
+          <port name="PAD_$out" type="input" from="bidir"/>
+          <port name="outpad" type="output" from="outpad"/>
+          <pack_pattern name="BIDIR_TO_OPAD" type="pack">
+            <port name="PAD_$out" type="input" from="bidir"/>
+            <port name="outpad" type="output" from="outpad"/>
+          </pack_pattern>
         </direct>
         <direct>
-          <port name="OQI" type="input"/>
-          <port name="O_DAT" type="output" from="bidir"/>
+          <port name="IQC" type="input"/>
+          <port name="IQC" type="output" from="bidir"/>
         </direct>
         <direct>
           <port name="IE" type="input"/>
-          <port name="O_EN" type="output" from="bidir"/>
+          <port name="IE" type="output" from="bidir"/>
         </direct>
         <direct>
-          <port name="I_DAT" type="input" from="bidir"/>
+          <port name="INEN" type="input"/>
+          <port name="INEN" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQE" type="input"/>
+          <port name="IQE" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQIN" type="input"/>
+          <port name="IQIN" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQR" type="input"/>
+          <port name="IQR" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="OQE" type="input"/>
+          <port name="OQE" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="OQI" type="input"/>
+          <port name="OQI" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQZ" type="input" from="bidir"/>
+          <port name="IQZ" type="output"/>
+        </direct>
+        <direct>
+          <port name="IZ" type="input" from="bidir"/>
           <port name="IZ" type="output"/>
-        </direct>
-        <direct>
-          <port name="O_PAD_$out" type="input" from="bidir"/>
-          <port name="outpad" type="output" from="outpad"/>
-          <pack_pattern name="BIDIR_TO_OPAD" type="pack">
-            <port name="O_PAD_$out" type="input" from="bidir"/>
-            <port name="outpad" type="output" from="outpad"/>
-          </pack_pattern>
         </direct>
       </interconnect>
     </pb_type>
@@ -240,36 +288,60 @@ INV.DS=DS</meta>
       </pb_type>
       <interconnect>
         <direct>
-          <port name="INEN" type="input"/>
-          <port name="I_EN" type="output" from="bidir"/>
-        </direct>
-        <direct>
           <port name="inpad" type="input" from="inpad"/>
-          <port name="I_PAD_$inp" type="output" from="bidir"/>
+          <port name="PAD_$inp" type="output" from="bidir"/>
           <pack_pattern name="IOPAD_TO_BIDIR" type="pack">
             <port name="inpad" type="input" from="inpad"/>
-            <port name="I_PAD_$inp" type="output" from="bidir"/>
+            <port name="PAD_$inp" type="output" from="bidir"/>
           </pack_pattern>
         </direct>
         <direct>
-          <port name="OQI" type="input"/>
-          <port name="O_DAT" type="output" from="bidir"/>
+          <port name="PAD_$out" type="input" from="bidir"/>
+          <port name="outpad" type="output" from="outpad"/>
+          <pack_pattern name="IOPAD_TO_BIDIR" type="pack">
+            <port name="PAD_$out" type="input" from="bidir"/>
+            <port name="outpad" type="output" from="outpad"/>
+          </pack_pattern>
+        </direct>
+        <direct>
+          <port name="IQC" type="input"/>
+          <port name="IQC" type="output" from="bidir"/>
         </direct>
         <direct>
           <port name="IE" type="input"/>
-          <port name="O_EN" type="output" from="bidir"/>
+          <port name="IE" type="output" from="bidir"/>
         </direct>
         <direct>
-          <port name="I_DAT" type="input" from="bidir"/>
+          <port name="INEN" type="input"/>
+          <port name="INEN" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQE" type="input"/>
+          <port name="IQE" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQIN" type="input"/>
+          <port name="IQIN" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQR" type="input"/>
+          <port name="IQR" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="OQE" type="input"/>
+          <port name="OQE" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="OQI" type="input"/>
+          <port name="OQI" type="output" from="bidir"/>
+        </direct>
+        <direct>
+          <port name="IQZ" type="input" from="bidir"/>
+          <port name="IQZ" type="output"/>
+        </direct>
+        <direct>
+          <port name="IZ" type="input" from="bidir"/>
           <port name="IZ" type="output"/>
-        </direct>
-        <direct>
-          <port name="O_PAD_$out" type="input" from="bidir"/>
-          <port name="outpad" type="output" from="outpad"/>
-          <pack_pattern name="IOPAD_TO_BIDIR" type="pack">
-            <port name="O_PAD_$out" type="input" from="bidir"/>
-            <port name="outpad" type="output" from="outpad"/>
-          </pack_pattern>
         </direct>
       </interconnect>
     </pb_type>

--- a/quicklogic/pp3/primitives/bidir/bidir_cell.model.xml
+++ b/quicklogic/pp3/primitives/bidir/bidir_cell.model.xml
@@ -1,14 +1,20 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <model name="BIDIR_CELL">
     <input_ports>
-      <port name="I_EN" combinational_sink_ports="I_DAT"/>
-      <port name="I_PAD_$inp" combinational_sink_ports="I_DAT"/>
-      <port name="O_DAT" combinational_sink_ports="O_PAD_$out"/>
-      <port name="O_EN" combinational_sink_ports="O_PAD_$out"/>
+      <port name="PAD_$inp" combinational_sink_ports="IZ"/>
+      <port name="IE" combinational_sink_ports="PAD_$out"/>
+      <port name="OQI" combinational_sink_ports="PAD_$out"/>
+      <port name="OQE"/>
+      <port name="IQE"/>
+      <port name="IQC"/>
+      <port name="IQR"/>
+      <port name="INEN" combinational_sink_ports="IZ"/>
+      <port name="IQIN"/>
     </input_ports>
     <output_ports>
-      <port name="I_DAT"/>
-      <port name="O_PAD_$out"/>
+      <port name="IZ"/>
+      <port name="IQZ"/>
+      <port name="PAD_$out"/>
     </output_ports>
   </model>
 </models>

--- a/quicklogic/pp3/primitives/bidir/bidir_cell.pb_type.xml
+++ b/quicklogic/pp3/primitives/bidir/bidir_cell.pb_type.xml
@@ -1,16 +1,22 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="BIDIR_CELL">
   <blif_model>.subckt BIDIR_CELL</blif_model>
-  <input name="I_EN" num_pins="1"/>
-  <input name="I_PAD_$inp" num_pins="1"/>
-  <input name="O_DAT" num_pins="1"/>
-  <input name="O_EN" num_pins="1"/>
-  <output name="I_DAT" num_pins="1"/>
-  <output name="O_PAD_$out" num_pins="1"/>
-  <delay_constant in_port="I_EN" out_port="I_DAT" max="1e-10"/>
-  <delay_constant in_port="I_PAD_$inp" out_port="I_DAT" max="{iopath_IP_IZ}"/>
-  <delay_constant in_port="O_DAT" out_port="O_PAD_$out" max="{iopath_OQI_IP}"/>
-  <delay_constant in_port="O_EN" out_port="O_PAD_$out" max="{iopath_IE_IP}"/>
+  <input name="PAD_$inp" num_pins="1"/>
+  <input name="IE" num_pins="1"/>
+  <input name="OQI" num_pins="1"/>
+  <input name="OQE" num_pins="1"/>
+  <input name="IQE" num_pins="1"/>
+  <input name="IQC" num_pins="1"/>
+  <input name="IQR" num_pins="1"/>
+  <input name="INEN" num_pins="1"/>
+  <input name="IQIN" num_pins="1"/>
+  <output name="IZ" num_pins="1"/>
+  <output name="PAD_$out" num_pins="1"/>
+  <output name="IQZ" num_pins="1"/>
+  <delay_constant in_port="INEN" out_port="IZ" max="1e-10"/>
+  <delay_constant in_port="PAD_$inp" out_port="IZ" max="{iopath_IP_IZ}"/>
+  <delay_constant in_port="OQI" out_port="PAD_$out" max="{iopath_OQI_IP}"/>
+  <delay_constant in_port="IE" out_port="PAD_$out" max="{iopath_IE_IP}"/>
   <metadata>
     <meta name="fasm_params">INV.ESEL=ESEL
 INV.OSEL=OSEL

--- a/quicklogic/pp3/primitives/bidir/bidir_cell.sim.v
+++ b/quicklogic/pp3/primitives/bidir/bidir_cell.sim.v
@@ -2,30 +2,34 @@
 (* whitebox *)
 (* FASM_PARAMS="INV.ESEL=ESEL;INV.OSEL=OSEL;INV.FIXHOLD=FIXHOLD;INV.WPD=WPD;INV.DS=DS" *)
 module BIDIR_CELL(
-    I_PAD_$inp, I_DAT, I_EN,
-    O_PAD_$out, O_DAT, O_EN
+    PAD_$inp, PAD_$out,
+    IE, OQI, OQE,
+    IQE, IQC, IQR,
+    INEN, IQIN,
+    IZ, IQZ
 );
     (* iopad_external_pin *)
-    input  wire I_PAD_$inp;
-    input  wire I_EN;
+    input  wire PAD_$inp;
+    (* iopad_external_pin *)
+    output wire PAD_$out;
 
-    input  wire O_DAT;
-    input  wire O_EN;
+    input  wire IE;
+    input  wire OQI;
+    input  wire OQE;
+    input  wire IQE;
+    input  wire IQC;
+    input  wire IQR;
+    input  wire INEN;
+    input  wire IQIN;
 
-    (* DELAY_CONST_I_PAD_$inp="{iopath_IP_IZ}" *)
-    (* DELAY_CONST_I_EN="1e-10" *)  // No timing for IE/INEN -> IZ in LIB/SDF.
-    output wire I_DAT;
+    output wire IZ;
+    output wire IQZ;
 
-    (* DELAY_CONST_O_DAT="{iopath_OQI_IP}" *)
-    (* DELAY_CONST_O_EN="{iopath_IE_IP}" *)
-	(* iopad_external_pin *)
-    output wire O_PAD_$out;
-	
     specify
-        (O_DAT => O_PAD_$out) = (0,0);
-        (O_EN => O_PAD_$out) = (0,0);
-        (I_PAD_$inp => I_DAT) = (0,0);
-        (I_EN => I_DAT) = (0,0);
+        (OQI => PAD_$out) = (0,0);
+        (IE => PAD_$out) = (0,0);
+        (PAD_$inp => IZ) = (0,0);
+        (INEN => IZ) = (0,0);
     endspecify
 
     // Parameters
@@ -36,7 +40,7 @@ module BIDIR_CELL(
     parameter [0:0] DS      = 0;
 
     // Behavioral model
-    assign I_DAT = (I_EN == 1'b1) ? I_PAD_$inp : 1'b0;
-    assign O_PAD_$out = (O_EN == 1'b1) ? O_DAT : 1'b0;
+    assign IZ = (INEN == 1'b1) ? PAD_$inp : 1'b0;
+    assign PAD_$out = (IE == 1'b1) ? OQI : 1'b0;
 
 endmodule

--- a/quicklogic/pp3/techmap/cells_map.v
+++ b/quicklogic/pp3/techmap/cells_map.v
@@ -35,18 +35,24 @@ module inpad(output Q, input P);
   end else begin
 
       BIDIR_CELL # (
-      .ESEL     (1'b1),
+      .ESEL     (1'b0),
       .OSEL     (1'b1),
       .FIXHOLD  (1'b0),
       .WPD      (1'b0),
       .DS       (1'b0)
       ) _TECHMAP_REPLACE_ (
-      .I_PAD_$inp(P),
-      .I_DAT(Q),
-      .I_EN (1'b1),
-      .O_PAD_$out(),
-      .O_DAT(),
-      .O_EN (1'b0)
+      .PAD_$out (),
+      .PAD_$inp (P),
+      .IE       (1'b0),
+      .OQI      (1'b0),
+      .OQE      (1'b0),
+      .IZ       (Q),
+      .IQZ      (),
+      .IQE      (1'b0),
+      .INEN     (1'b1),
+      .IQIN     (1'b0),
+      .IQR      (1'b0),
+      .IQC      (1'b0)
       );
 
   end endgenerate
@@ -79,12 +85,18 @@ module outpad(output P, input A);
       .WPD      (1'b0),
       .DS       (1'b0)
       ) _TECHMAP_REPLACE_ (
-      .I_PAD_$inp(),
-      .I_DAT(),
-      .I_EN (1'b0),
-      .O_PAD_$out(P),
-      .O_DAT(A),
-      .O_EN (1'b1)
+      .PAD_$out (P),
+      .PAD_$inp (),
+      .IE       (1'b1),
+      .OQI      (A),
+      .OQE      (1'b0),
+      .IZ       (Q),
+      .IQZ      (),
+      .IQE      (1'b0),
+      .INEN     (1'b0),
+      .IQIN     (1'b0),
+      .IQR      (1'b0),
+      .IQC      (1'b1)
       );
 
   end endgenerate
@@ -124,12 +136,18 @@ module bipad(input A, input EN, output Q, inout P);
       .WPD      (1'b0),
       .DS       (1'b0)
       ) _TECHMAP_REPLACE_ (
-      .I_PAD_$inp(P),
-      .I_DAT(Q),
-      .I_EN (1'b1),
-      .O_PAD_$out(P),
-      .O_DAT(A),
-      .O_EN (EN)
+      .PAD_$out (P),
+      .PAD_$inp (P),
+      .IE       (EN),
+      .OQI      (A),
+      .OQE      (1'b0),
+      .IZ       (Q),
+      .IQZ      (),
+      .IQE      (1'b0),
+      .INEN     (1'b1),
+      .IQIN     (1'b0),
+      .IQR      (1'b0),
+      .IQC      (1'b1)
       );
 
   end endgenerate
@@ -146,7 +164,7 @@ module ckpad(output Q, input P);
   // cell.
   generate if (IO_TYPE == "" || IO_TYPE == "CLOCK") begin
 
-      // In VPR GMUX has to be explicityl present in the netlist. Add it here.
+      // In VPR GMUX has to be explicitly present in the netlist. Add it here.
 
       wire C;
 


### PR DESCRIPTION
This PR changes the way in which the `BIDIR` cell is modeled for PP3 so that all its input/output pins can be explicitly routed by VPR.

This does not bring any new functionality but opens a way for having a default bitstream which contains default routes for `BIDIR` inputs which can then be overriden by a design.