### PR TITLE
QL: GH-A: enable automerge for dependebot PRs

### DIFF
--- a/.github/workflows/quicklogic.yml
+++ b/.github/workflows/quicklogic.yml
@@ -218,3 +218,23 @@ jobs:
           GCP_SERVICE_ACCOUNT_KEY_FILE: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY_FILE }}
           GCP_STORAGE_BUCKET: ${{ secrets.GCP_STORAGE_BUCKET }}
           SOURCE_DIR: "latest-package"
+
+  Automerge:
+    name: Automerge dependabot pull requests
+    permissions:
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    needs: upload-architectures
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I'm not sure if the approval requirement will not block automerging. We need to check this