### PR TITLE
utils: vpr fixup: merge only top module port signals

### DIFF
--- a/quicklogic/common/cmake/quicklogic_install.cmake
+++ b/quicklogic/common/cmake/quicklogic_install.cmake
@@ -189,7 +189,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
           FILES_MATCHING PATTERN *.v)
 
   # install cells_sim.v from yosys plugins
-  if ("${FAMILY}" STREQUAL "pp3")
+  if ("${FAMILY}" STREQUAL "pp3" OR "${FAMILY}" STREQUAL "qlf_k4n8")
     set(YOSYS_CELLS_SIM_LOCAL "techmap/yosys_cells_sim.v")
     get_file_target(YOSYS_CELLS_SIM_TARGET ${YOSYS_CELLS_SIM_LOCAL})
     get_file_location(YOSYS_CELLS_SIM_LOCAL ${YOSYS_CELLS_SIM_LOCAL})

--- a/quicklogic/common/cmake/quicklogic_toolchain_test.cmake
+++ b/quicklogic/common/cmake/quicklogic_toolchain_test.cmake
@@ -82,15 +82,15 @@ function(ADD_BINARY_TOOLCHAIN_TEST)
   if("${DIRECTIVE}" STREQUAL "compile")
     list(APPEND ASSERT_EXISTS "${BUILD_DIR}/top.net")
     list(APPEND ASSERT_EXISTS "${BUILD_DIR}/top.place")
-    list(APPEND ASSERT_EXISTS "${BUILD_DIR}/top.fasm")
-    list(APPEND ASSERT_EXISTS "${BUILD_DIR}/top.bit")
   endif()
 
-  # qlf* architectures use repacker hence the "top.route" name is
-  # different.
+  # qlf* architectures use repacker hence the "top.route" name is different.
+  # It also don't support fasm and bitstream generation yet
   if("${DEVICE}" MATCHES "qlf_.*")
     list(APPEND ASSERT_EXISTS "${BUILD_DIR}/top.repacked.route")
   else()
+    list(APPEND ASSERT_EXISTS "${BUILD_DIR}/top.fasm")
+    list(APPEND ASSERT_EXISTS "${BUILD_DIR}/top.bit")
     list(APPEND ASSERT_EXISTS "${BUILD_DIR}/top.route")
   endif()
 

--- a/quicklogic/qlf_k4n8/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/CMakeLists.txt
@@ -24,6 +24,25 @@ set(VPR_ARCH_ARGS "\
     --absorb_buffer_luts off "
 )
 
+# copy yosys cells_sim.v to techmap directory and comment out includes
+set(YOSYS_CELLS_SIM ${YOSYS_DATADIR}/quicklogic/${FAMILY_NAME}/cells_sim.v)
+set(YOSYS_CELLS_SIM_LOCAL techmap/yosys_cells_sim.v)
+get_file_target(YOSYS_CELLS_SIM_TARGET ${YOSYS_CELLS_SIM})
+if (NOT TARGET ${YOSYS_CELLS_SIM_TARGET})
+  add_file_target(FILE ${YOSYS_CELLS_SIM} ABSOLUTE)
+endif ()
+
+SET(SED_ARGS -i \"s\/\^\\\`include\/\\\/\\\/\\\`include\/\" ${YOSYS_CELLS_SIM_LOCAL})
+add_custom_command(
+  OUTPUT ${YOSYS_CELLS_SIM_LOCAL}
+  COMMAND ${CMAKE_COMMAND} -E copy
+	  ${YOSYS_CELLS_SIM}
+	  ${YOSYS_CELLS_SIM_LOCAL}
+  COMMAND sed ${SED_ARGS}
+  DEPENDS ${YOSYS_CELLS_SIM_TARGET}
+)
+add_file_target(FILE ${YOSYS_CELLS_SIM_LOCAL} GENERATED)
+
 # Define the architecture
 quicklogic_define_qlf_arch(
   FAMILY   ${FAMILY}

--- a/quicklogic/qlf_k4n8/tests/features/install_test/compile_args/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/install_test/compile_args/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_binary_toolchain_test(
     TEST_NAME  compile_args
+    ARCH       qlf_k4n8
     DEVICE     qlf_k4n8
     PINMAP     pinmap_qlf_k4n8_umc22.csv
     EXTRA_ARGS "+incdir+${CMAKE_CURRENT_SOURCE_DIR}/includes -y ${CMAKE_CURRENT_SOURCE_DIR}/libraries +libext+not_v"

--- a/quicklogic/qlf_k4n8/tests/features/install_test/counter_16bit/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/install_test/counter_16bit/CMakeLists.txt
@@ -1,5 +1,12 @@
 add_binary_toolchain_test(
     TEST_NAME counter_16bit
+    ARCH      qlf_k4n8
     DEVICE    qlf_k4n8
     PINMAP    pinmap_qlf_k4n8_umc22.csv
+    EXTRA_ARGS "-dump post_verilog"
+
+    ENABLE_SIMULATION
+
+    ASSERT_USAGE  io=19,clb=6
+    ASSERT_TIMING fmax>=156.0
 )

--- a/utils/vpr_fixup_post_synth.py
+++ b/utils/vpr_fixup_post_synth.py
@@ -159,6 +159,9 @@ def merge_verilog_ports(code):
         Creates single multi-bit port definition
         """
         base = match.group("base")
+        # Do not merge wires that are not top module ports
+        if base not in to_merge.keys():
+            return match.group(0)
         index = match.group("index")
         trailing_ws = match.group(0)[-1]
         port_usage = "{}[{}]{}".format(base, index, trailing_ws)


### PR DESCRIPTION
This PR fixes problems described in https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/766.

The problem was that the script was converting the names of all wires that have naming format like this: `\name[id]` even when the wire is not a top module port. With this PR I enabled simple filtration that will prevent this behaviour.

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>