### PR TITLE
CI: merge dependabot PRs directly

### DIFF
--- a/.github/workflows/quicklogic.yml
+++ b/.github/workflows/quicklogic.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automerge often fails with cryptic `Pull request is not in the correct state to enable auto-merge`. This PR replaces this with direct merge if all the required checks are green. This will effectively work like automerge