### PR TITLE
Fracturable LUT handling

### DIFF
--- a/quicklogic/common/utils/repacker/pb_rr_graph_netlist.py
+++ b/quicklogic/common/utils/repacker/pb_rr_graph_netlist.py
@@ -4,8 +4,6 @@ A set of utility functions responsible for loading a packed netlist into a
 complex block routing graph and creating a packed netlist from a graph with
 routing information.
 """
-import logging
-
 from block_path import PathNode
 
 import packed_netlist

--- a/quicklogic/common/utils/repacker/pb_rr_graph_netlist.py
+++ b/quicklogic/common/utils/repacker/pb_rr_graph_netlist.py
@@ -27,7 +27,8 @@ def get_block_by_path(block, path):
 
         # Check operating mode
         if path[0].mode is not None:
-            if block.mode != path[0].mode:
+            block_mode = "default" if block.mode is None else block.mode
+            if block_mode != path[0].mode:
                 return None
 
         # Recurse
@@ -191,7 +192,8 @@ def build_packed_netlist_from_pb_graph(clb_graph):
             continue
 
         # Operating mode of the parent must match
-        if parent.mode != parts[-3].mode:
+        parent_mode = "default" if parent.mode is None else parent.mode
+        if parent_mode != parts[-3].mode:
             continue
 
         # Check if the parent contains an open block correesponding to this

--- a/quicklogic/common/utils/repacker/pb_rr_graph_netlist.py
+++ b/quicklogic/common/utils/repacker/pb_rr_graph_netlist.py
@@ -258,7 +258,8 @@ def build_packed_netlist_from_pb_graph(clb_graph):
 
             # In case of multiple possibilities prefer SOURCE nodes over PORT
             # ones.
-            drivers = sorted(nodes_up[node.id],
+            drivers = sorted(
+                nodes_up[node.id],
                 key=lambda d: clb_graph.nodes[d[0]].type != NodeType.SOURCE
             )
             driver_node, driver_conn = next(iter(drivers))

--- a/quicklogic/common/utils/repacker/pb_rr_graph_netlist.py
+++ b/quicklogic/common/utils/repacker/pb_rr_graph_netlist.py
@@ -5,6 +5,7 @@ complex block routing graph and creating a packed netlist from a graph with
 routing information.
 """
 from block_path import PathNode
+from pb_rr_graph import NodeType
 
 import packed_netlist
 
@@ -254,8 +255,13 @@ def build_packed_netlist_from_pb_graph(clb_graph):
         driver_node = None
         driver_conn = None
         if node.id in nodes_up:
-            assert len(nodes_up[node.id]) <= 1, node.path
-            driver_node, driver_conn = next(iter(nodes_up[node.id]))
+
+            # In case of multiple possibilities prefer SOURCE nodes over PORT
+            # ones.
+            drivers = sorted(nodes_up[node.id],
+                key=lambda d: clb_graph.nodes[d[0]].type != NodeType.SOURCE
+            )
+            driver_node, driver_conn = next(iter(drivers))
 
         # Got a driver, this is an intermediate port
         if driver_node is not None:

--- a/quicklogic/common/utils/repacker/pb_rr_graph_router.py
+++ b/quicklogic/common/utils/repacker/pb_rr_graph_router.py
@@ -198,14 +198,13 @@ class Router:
                             )
                         )
 
+                # Log endpoints
+                for node in [self.graph.nodes[node_id] for node_id in net.sources]:
+                    logging.critical("     from {}".format(str(node)))
+                logging.critical("     to   {}".format(str(self.graph.nodes[sink])))
+
                 # Raise an exception
-                raise RuntimeError(
-                    "Unroutable net '{}' from {} to {}".format(
-                        net.name,
-                        [self.graph.nodes[node_id] for node_id in net.sources],
-                        self.graph.nodes[sink]
-                    )
-                )
+                raise RuntimeError("Unroutable net '{}'".format(net.name))
 
             # Annotate all nodes of the route
             for node_id in route:

--- a/quicklogic/common/utils/repacker/pb_rr_graph_router.py
+++ b/quicklogic/common/utils/repacker/pb_rr_graph_router.py
@@ -199,9 +199,13 @@ class Router:
                         )
 
                 # Log endpoints
-                for node in [self.graph.nodes[node_id] for node_id in net.sources]:
+                for node in [
+                        self.graph.nodes[node_id] for node_id in net.sources
+                ]:
                     logging.critical("     from {}".format(str(node)))
-                logging.critical("     to   {}".format(str(self.graph.nodes[sink])))
+                logging.critical(
+                    "     to   {}".format(str(self.graph.nodes[sink]))
+                )
 
                 # Raise an exception
                 raise RuntimeError("Unroutable net '{}'".format(net.name))

--- a/quicklogic/common/utils/repacker/pb_type.py
+++ b/quicklogic/common/utils/repacker/pb_type.py
@@ -312,11 +312,12 @@ class PbType:
         port = match.group("port")
         bits = match.group("bits")
 
-        # Find the port
-        assert port in self.ports, (self.name, port)
-        port = self.ports[port]
+        # Port not present
+        if port not in self.ports:
+            return
 
         # Yield the bits
+        port = self.ports[port]
         yield from port.yield_pins(bits)
 
     def find(self, path):

--- a/quicklogic/common/utils/repacker/pb_type.py
+++ b/quicklogic/common/utils/repacker/pb_type.py
@@ -226,6 +226,8 @@ class PbType:
 
         # Ports (indexed by name)
         self.ports = {}
+        # Metadata
+        self.metadata = {}
 
     @property
     def is_leaf(self):
@@ -295,6 +297,13 @@ class PbType:
 
             # Copy ports from the current pb_type
             child.ports = deepcopy(pb_type.ports)
+
+        # Get metadata
+        xml_metadata = elem.find("metadata")
+        if xml_metadata is not None:
+            for xml_meta in xml_metadata.findall("meta"):
+                name = xml_meta.attrib["name"]
+                pb_type.metadata[name] = xml_meta.text
 
         return pb_type
 

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -1192,11 +1192,9 @@ def expand_port_maps(rules, clb_pbtypes):
             assert len(src_pins) <= len(dst_pins), (src_pins, dst_pins)
             dst_pins = dst_pins[:len(src_pins)]
 
-            # Store destination port width
-            attrib["$width"] = dst_pbtype.ports[dst_pins[0][0]].width
-
             # Update port map
             for src_pin, dst_pin in zip(src_pins, dst_pins):
+                attrib["$width"] = dst_pbtype.ports[dst_pin[0]].width
                 port_map[src_pin] = {"port": dst_pin, **attrib}
 
         rule.port_map = port_map

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -60,14 +60,7 @@ class RepackingRule:
         Remaps the given source pb_type index to the destination pb_type index
         """
         index = index * self.index_map[0] + self.index_map[1]
-
-        # Ensure that even in case of floating point index_map coeffs the
-        # calculated index is integer.
-        if isinstance(index, float):
-            assert index.is_integer(), index
-            index = int(index)
-
-        return index
+        return int(index) # Truncate fraction
 
     def get_port_map(self, use_count=None):
         """
@@ -1200,7 +1193,14 @@ def write_packed_netlist(fname, netlist):
     Writes the given packed netlist to an XML file
     """
 
+    # Convert the packed netlist to ElementTree hierarchy
     xml_tree = ET.ElementTree(netlist.to_etree())
+
+    # Update file name
+    xml_root = xml_tree.getroot()
+    xml_root.set("name", os.path.basename(fname))
+
+    # Convert to string and write
     xml_data = '<?xml version="1.0"?>\n' \
              + ET.tostring(xml_tree, pretty_print=True).decode("utf-8")  # noqa: E127
 

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -1093,7 +1093,10 @@ def expand_port_maps(rules, clb_pbtypes):
             src_pins = list(src_pbtype.yield_port_pins(src_port))
             dst_pins = list(dst_pbtype.yield_port_pins(dst_port))
 
-            assert len(src_pins) == len(dst_pins), (src_pins, dst_pins)
+            # Number of source pins can be lower than destination pins but
+            # not vice-versa.
+            assert len(src_pins) <= len(dst_pins), (src_pins, dst_pins)
+            dst_pins = dst_pins[:len(src_pins)]
 
             # Update port map
             for src_pin, dst_pin in zip(src_pins, dst_pins):

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -805,7 +805,10 @@ def merge_truth_table(init, chunk, out_port, dst_pbtype):
         mask_ofs = 0
         mask_len = len(init)
 
-        logging.warning("WARNING: no LUT metadata 'lut_ports' for LUT pb_type '{}', assuming non-fracturable LUT".format(dst_pbtype.name))
+        logging.warning(
+            "WARNING: no LUT metadata 'lut_ports' for LUT pb_type '{}', "
+            "assuming non-fracturable LUT".format(dst_pbtype.name)
+        )
 
     # A fracturable LUT
     else:
@@ -817,17 +820,22 @@ def merge_truth_table(init, chunk, out_port, dst_pbtype):
         # Get LUT input port
         for port, data in lut_ports.items():
             if data["type"] == "input":
-                in_port = port
+                #               in_port = port
                 break
         else:
-            raise RuntimeError("Destination LUT pb_type '{}' does not define a LUT input port".format(dst_pbtype.name))
+            raise RuntimeError(
+                "Destination LUT pb_type '{}' does not define a LUT input port"
+                .format(dst_pbtype.name)
+            )
 
         # Get LUT width
-        lut_width = dst_pbtype.ports[in_port].width
-        # Get mapped output port metadata
+
+
+#       lut_width = dst_pbtype.ports[in_port].width
+# Get mapped output port metadata
         port_data = lut_ports[out_port.name]
 
-        frac_lvl  = int(port_data["lut_frac_level"])
+        frac_lvl = int(port_data["lut_frac_level"])
         frac_mask = [int(i) for i in port_data["lut_output_mask"].split(",")]
 
         # Build LUT init mask
@@ -888,7 +896,9 @@ def repack_netlist_cell(
         return dst
 
     # Get source block cumulative index
-    cumulative_index = get_cumulative_index(src_pbtype, block.get_path(), dst_path)
+    cumulative_index = get_cumulative_index(
+        src_pbtype, block.get_path(), dst_path
+    )
 
     # Get port map
     port_map = rule.get_port_map(cumulative_index)
@@ -1022,7 +1032,9 @@ def repack_netlist_cell(
 
         # Get or initialize the LUT init parameter for the destination cell
         # When initializing mark all bits as "x"
-        lut_init = list(repacked_cell.parameters.get("LUT", ["x"] * (1 << lut_width)))
+        lut_init = list(
+            repacked_cell.parameters.get("LUT", ["x"] * (1 << lut_width))
+        )
 
         # Create an init vector for a constant generator
         if cell.type == "$const":
@@ -1036,7 +1048,11 @@ def repack_netlist_cell(
 
         # Store parameter
         repacked_cell.parameters["LUT"] = "".join(lut_init)
-        logging.debug("     LUT={}'b{}".format(1 << lut_width, repacked_cell.parameters["LUT"]))
+        logging.debug(
+            "     LUT={}'b{}".format(
+                1 << lut_width, repacked_cell.parameters["LUT"]
+            )
+        )
 
     # Process parameters for "adder_lut4"
     if cell.type == "adder_lut4":
@@ -1679,8 +1695,8 @@ def main():
             exit(-1)
 
         # Make the constraints
-        for (net, net_pbtypes), (port, arch_pbtypes) in \
-            zip(free_clock_nets.items(), free_clock_routes.items()):
+        for (net, net_pbtypes), (port, arch_pbtypes) in zip(
+                free_clock_nets.items(), free_clock_routes.items()):
 
             # Some CLBs that have global clocks connected do not have the
             # require port. Report an error.
@@ -1690,8 +1706,7 @@ def main():
                     " ERROR: Cannot constrain global clock net '{}' as the "
                     "block types {} requiring it do not have the port "
                     "'{}'".format(
-                        net,
-                        ", ".join(["'{}'".format(b) for b in missing]),
+                        net, ", ".join(["'{}'".format(b) for b in missing]),
                         port
                     )
                 )
@@ -1791,8 +1806,12 @@ def main():
                 assert pb_type is not None, pb_path
 
                 # Compute and remap cumulative index
-                cumulative_index = get_cumulative_index(pb_type, blk_path, arch_path)
-                arch_path[-1].index = rule.remap_pb_type_index(cumulative_index)
+                cumulative_index = get_cumulative_index(
+                    pb_type, blk_path, arch_path
+                )
+                arch_path[-1].index = rule.remap_pb_type_index(
+                    cumulative_index
+                )
 
             arch_path = ".".join([str(p) for p in arch_path])
 

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -771,16 +771,17 @@ def repack_netlist_cell(eblif, cell, existing_cell_name, block, src_pbtype, dst_
     if existing_cell_name is None:
         repacked_cell = Cell(model.name)
         repacked_cell.name = cell.name
+        repacked_cell.cname = cell.cname
 
     else:
         repacked_cell = eblif.cells[existing_cell_name]
         repacked_cell.name += "_" + cell.name
+        repacked_cell.cname = repacked_cell.name
         del eblif.cells[existing_cell_name]
 
     logging.debug("    " + str(repacked_cell.name))
 
-    # Copy cell data
-    repacked_cell.cname = cell.cname
+    # Merge attributes and parameters
     update_dict(repacked_cell.attributes, cell.attributes, "Cell '{}' ({}) attribute ".format(repacked_cell.name, model.name))
     update_dict(repacked_cell.parameters, cell.parameters, "Cell '{}' ({}) parameter ".format(repacked_cell.name, model.name))
 

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -122,7 +122,7 @@ def fixup_route_throu_luts(clb_block, new_net_ids):
 
         # This is a leaf block
         if block.is_leaf:
-            if block.is_route_throu:
+            if block.is_route_throu_lut:
                 blocks.append(block)
 
         # Recurse for all children
@@ -1839,10 +1839,11 @@ def main():
                 assert dst_block is not None, dst_path
 
                 name = leaf_block_names[dst_path]
-                logging.debug(
-                    "   renaming leaf block {} to {}".format(dst_block, name)
-                )
-                dst_block.name = name
+                if dst_block.name != name:
+                    logging.debug(
+                        "   renaming leaf block {} to {}".format(dst_block, name)
+                    )
+                    dst_block.name = name
 
         # Replace the CLB
         packed_netlist.blocks[clb_block.instance] = repacked_clb_block

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -812,7 +812,7 @@ def repack_netlist_cell(
 
     # Update cell attributes / parameters checking for conflicts
     def update_dict(dst, src, msg):
-        for k, v in src:
+        for k, v in src.items():
             if k not in dst:
                 dst[k] = v
             elif dst[k] != v:
@@ -935,18 +935,29 @@ def repack_netlist_cell(
     # truth table as a parameter to the repacked cell.
     if cell.type == "$lut":
 
-        #        # Build the init parameter
-        #        init = rotate_truth_table(cell.init, lut_rotation)
-        #        init = "".join(["1" if x else "0" for x in init][::-1])
-        #
-        #        # Expand the truth table to match the physical LUT width. Do that by
-        #        # repeating the lower part of it until the desired length is attained.
-        #        while (len(init).bit_length() - 1) < lut_width:
-        #            init = init + init
-        #
-        #        # Reverse LUT bit order
-        #        init = init[::-1]
-        init = "0"
+        # FIXME: Try handling LUTs. Should work for one-to-one repacking
+        # will fail on many-to-one repacking.
+        try:
+
+            # Build the init parameter
+            init = rotate_truth_table(cell.init, lut_rotation)
+            init = "".join(["1" if x else "0" for x in init][::-1])
+
+            # Expand the truth table to match the physical LUT width. Do that by
+            # repeating the lower part of it until the desired length is attained.
+            while (len(init).bit_length() - 1) < lut_width:
+                init = init + init
+
+            # Reverse LUT bit order
+            init = init[::-1]
+
+        except Exception as ex:
+            init = "0" * (1 << lut_width)
+            logging.error(
+                "FIXME: Cannot handle LUT equation for '{}', {}".format(
+                    cell.name, repr(ex)
+                )
+            )
 
         repacked_cell.parameters["LUT"] = init
 

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -512,7 +512,10 @@ def get_cumulative_index(block, pb_type, dst_path):
     dst_path = [PathNode.from_string(p) for p in dst_path.split(".")]
 
     # Must be the same CLB
-    assert str(src_path[0]) == str(dst_path[0])
+    assert src_path[0].name == dst_path[0].name and \
+           src_path[0].index == dst_path[0].index, \
+           (".".join(src_path),
+            ".".join(dst_path))
 
     # Find the divergence point of the paths. This is the pb_type in physical
     # mode.

--- a/quicklogic/common/utils/repacker/repack.py
+++ b/quicklogic/common/utils/repacker/repack.py
@@ -896,13 +896,16 @@ def repack_netlist_cell(
         # Add port index for 1-bit ports
         if port.index is None:
             port.index = 0
-        org_port = port
 
-        # Undo VPR port rotation
+        org_index = port.index
+
+        # Apply VPR port rotation
         blk_port = block.ports[port.name]
         if blk_port.rotation_map:
             inv_rotation_map = {v: k for k, v in blk_port.rotation_map.items()}
             port.index = inv_rotation_map[port.index]
+
+        org_port = PathNode(port.name, port.index)
 
         # Remap the port
         if port_map is not None:
@@ -929,9 +932,9 @@ def repack_netlist_cell(
         connect(port, net)
 
         # Update LUT rotation if applicable
-        if port.name == lut_in:
+        if org_port.name == lut_in:
             assert port.index not in lut_rotation
-            lut_rotation[port.index] = org_port.index
+            lut_rotation[port.index] = org_index
             lut_width = width
 
     # If the cell is a LUT then rotate its truth table. Append the rotated

--- a/quicklogic/qlf_k4n8/tests/features/post_synthesis_seq/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/features/post_synthesis_seq/CMakeLists.txt
@@ -19,7 +19,7 @@ add_custom_target(
   post_synthesis_seq
   COMMAND ${IVERILOG} -v -gspecify -o counter_16bit.vvp ${COUNTER_TB} ${POST_SYNTH_FILE} ${CELLS_SIM}
   DEPENDS ${IVERILOG}
-  COMMAND ${VVP} -v counter_16bit.vvp -sdf-verbose | egrep -q -w "97"
+  COMMAND ${VVP} -v counter_16bit.vvp -sdf-verbose | tee counter_16bit.vvp.log | egrep -q -w "97"
   DEPENDS ${VVP}
   DEPENDS counter_16bit_test4-umc22-adder_analysis
   )


### PR DESCRIPTION
**This PR depends on https://github.com/QuickLogic-Corp/symbiflow-arch-defs/pull/1049 which has to be merged first.**

The PR adds/fixes:
 - added support for merging LUT init vectors (a.k.a. equation) when repacking multiple LUTs into a physical fracturable one
 - corrected determining source pb_type index when repacking
 - fixed global clock constraint mechanism so that it does not assign nets to non-existing ports
 - fixed incorrect route-thru blocks writing which made VPR crash
 - fixes other minor issues / corner cases